### PR TITLE
fix(cdrcheckbox): add v-model bound to computed checkboxModel. Add cu…

### DIFF
--- a/src/components/checkbox/CdrCheckbox.vue
+++ b/src/components/checkbox/CdrCheckbox.vue
@@ -91,11 +91,11 @@ const props = defineProps({
  const emit = defineEmits(['update:modelValue'])
 
  const vIndeterminate = (el, binding)=>{
-    if(!binding.value) {
-      el.removeAttribute("indeterminate");
+    if(!!binding.value) {
+      el.setAttribute("indeterminate", binding.value)
       return;
     }
-    el.setAttribute("indeterminate", "indeterminate")
+    el.removeAttribute("indeterminate");
   }
  const checkboxModel = computed({
   get() {

--- a/src/components/checkbox/CdrCheckbox.vue
+++ b/src/components/checkbox/CdrCheckbox.vue
@@ -13,19 +13,24 @@
         :class="[style['cdr-checkbox__input'], inputClass]"
         type="checkbox"
         v-bind="$attrs"
-        :checked="newValue"
-        @change="$emit('update:modelValue', $event.target.checked, $event)"
         :true-value="customValue ? null : trueValue"
         :false-value="customValue ? null : falseValue"
         :value="customValue"
-        :indeterminate="indeterminate"
-      >
+        v-indeterminate="indeterminate"
+        v-model="checkboxModel"
+      />
     </template>
     <slot />
   </cdr-label-wrapper>
 </template>
+<script>
+export default {
+  inheritAttrs: false,
+  customOptions: {}
+}
+</script>
 <script setup>
-import { useCssModule, ref, watch } from 'vue';
+import { useCssModule, computed } from 'vue';
 import CdrLabelWrapper from '../labelWrapper/CdrLabelWrapper';
 import sizeProps from '../../props/size';
 import propValidator from '../../utils/propValidator';
@@ -48,7 +53,7 @@ const props = defineProps({
    * Show checkbox in indeterminate state. (NOTE: this is a visual-only state and there is no logic for when to show it)
   */
   indeterminate: {
-    type: Boolean,
+    type: [Boolean, String],
     default: false,
   },
   /**
@@ -83,14 +88,25 @@ const props = defineProps({
     type: [String, Number, Boolean, Object, Array, Symbol, Function],
   }
 });
+ const emit = defineEmits(['update:modelValue'])
 
+ const vIndeterminate = (el, binding)=>{
+    if(!binding.value) {
+      el.removeAttribute("indeterminate");
+      return;
+    }
+    el.setAttribute("indeterminate", "indeterminate")
+  }
+ const checkboxModel = computed({
+  get() {
+    return props.modelValue
+  },
+  set(newValue) {
+    emit('update:modelValue', newValue)
+  }
+})
 const style = useCssModule();
 const baseClass = 'cdr-checkbox';
-const newValue = ref(props.modelValue);
-
-watch(() => props.value, (val) => {
-  newValue.value = val;
-})
 </script>
 <style lang="scss" module src="./styles/CdrCheckbox.module.scss">
 </style>

--- a/src/components/checkbox/examples/checkboxes.vue
+++ b/src/components/checkbox/examples/checkboxes.vue
@@ -102,10 +102,10 @@
     </div>
 
     <cdr-checkbox
-      indeterminate
+      indeterminate="true"
     >indeterminate (not functional)</cdr-checkbox>
     <cdr-checkbox
-      indeterminate
+      indeterminate="true"
       disabled
     >indeterminate (not functional)</cdr-checkbox>
 

--- a/src/components/checkbox/examples/checkboxes.vue
+++ b/src/components/checkbox/examples/checkboxes.vue
@@ -84,6 +84,7 @@
     >F</cdr-checkbox>
 
     <cdr-text>group: {{ exGroup }}</cdr-text>
+    <cdr-text>Note: Arrays currently can't be nested in an array of values. The value becomes stringified. This appears to be a bug in Vue. Try toggling the "F" checkbox to see the current effect of nesting an array value</cdr-text>
 
     <cdr-checkbox disabled>
       disabled checkbox
@@ -102,10 +103,10 @@
     </div>
 
     <cdr-checkbox
-      indeterminate="true"
+      indeterminate
     >indeterminate (not functional)</cdr-checkbox>
     <cdr-checkbox
-      indeterminate="true"
+      indeterminate
       disabled
     >indeterminate (not functional)</cdr-checkbox>
 


### PR DESCRIPTION
…stom indeterminate directive

In order to properly update checkbox group, we had to bind v-model with a computed checkboxModel
with its own custom getter and setter. In addtion, since the 'indeterminate' property wasn't being
applied to the input regardless of what was being passed to :indeterminate, I created a custom
vIndeterminate which would add/remove the indeterminate prop from the checkbox input.

Also, there is an outstanding issue where arrays that are passed as values to checkbox groups are stringified and have the brackets removed. After some research I believe this to be a bug in vue itself. Since the use case seems very limited, I've created a story to look at it later: https://issues.rei.com/browse/CDR-2472

CDR-2458
