### PR TITLE
Pr/cdr 2153 refactor cdr input

### DIFF
--- a/src/components/formError/CdrFormError.vue
+++ b/src/components/formError/CdrFormError.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="style[baseClass]" role="status" tabindex="0">
+  <div :class="style[baseClass]" role="status">
     <span :class="style[iconClass]">
       <icon-error-stroke size="small" inherit-color />
     </span>

--- a/src/components/formError/__tests__/__snapshots__/CdrFormError.spec.js.snap
+++ b/src/components/formError/__tests__/__snapshots__/CdrFormError.spec.js.snap
@@ -4,7 +4,6 @@ exports[`CdrFormError matches snapshot 1`] = `
 <div
   class="cdr-form-error"
   role="status"
-  tabindex="0"
 >
   <span
     class="cdr-form-error__icon"

--- a/src/components/formGroup/__tests__/__snapshots__/CdrFormGroup.spec.js.snap
+++ b/src/components/formGroup/__tests__/__snapshots__/CdrFormGroup.spec.js.snap
@@ -48,7 +48,6 @@ exports[`CdrFormGroup renders error state correctly 1`] = `
     class="cdr-form-error"
     id="renders-error"
     role="status"
-    tabindex="0"
   >
     <span
       class="cdr-form-error__icon"

--- a/src/components/input/CdrInput.vue
+++ b/src/components/input/CdrInput.vue
@@ -224,8 +224,8 @@ const focusedClass = computed(() => isFocused.value && 'cdr-input--focus');
 
 const describedby = computed(() => {
   return [
-    slots['helper-text-top'] ? `${props.id}-helper-text-top` : '',
-    slots['helper-text-bottom'] ? `${props.id}-helper-text-bottom` : '',
+    slots['helper-text-top'] ? `${uniqueId}-helper-text-top` : '',
+    slots['helper-text-bottom'] ? `${uniqueId}-helper-text-bottom` : '',
     attrs['aria-describedby'],
   ].filter((x) => x).join(' ');
 })

--- a/src/components/input/CdrInput.vue
+++ b/src/components/input/CdrInput.vue
@@ -151,7 +151,6 @@ const props = defineProps({
       default: 'text',
       validator: (value) => propValidator(
         value,
-        // TODO: moar types?
         ['text', 'email', 'number', 'password', 'search', 'url', 'tel'],
       ),
     },
@@ -200,7 +199,6 @@ const props = defineProps({
     },
 })
 const baseClass = 'cdr-input';
-// console.log(ctx.slots['post-icon']);
 // TODO: delete un-used hasSlot props
 const isFocused = ref(false);
 const slots = useSlots();
@@ -234,7 +232,6 @@ const describedby = computed(() => {
 
 const attrsWithClassExcluded = computed(()=>{
   let returnObj = {}
-  // use const below
   for (const attr in attrs) {
     if (attr !== 'class') {
       returnObj[attr] = attrs[attr]

--- a/src/components/input/CdrInput.vue
+++ b/src/components/input/CdrInput.vue
@@ -40,7 +40,7 @@
         :disabled="disabled"
         :aria-required="required || null"
         :aria-invalid="!!error || null"
-        :aria-errormessage="(!!error && `${id}-error`) || null"
+        :aria-errormessage="(!!error && `${uniqueId}-error`) || null"
         v-bind="inputAttrs"
         :aria-describedby="describedby || null"
         @focus="isFocused = true"
@@ -63,7 +63,7 @@
         :disabled="disabled"
         :aria-required="required || null"
         :aria-invalid="!!error || null"
-        :aria-errormessage="(!!error && `${id}-error`) || null"
+        :aria-errormessage="(!!error && `${uniqueId}-error`) || null"
         v-bind="inputAttrs"
         :aria-describedby="describedby || null"
         @focus="isFocused = true"
@@ -106,7 +106,7 @@
       <cdr-form-error
         :error="error"
         :role="errorRole"
-        :id="`${id}-error`"
+        :id="`${uniqueId}-error`"
         v-if="error"
       >
         <template #error>

--- a/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
+++ b/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
@@ -101,7 +101,6 @@ exports[`CdrInput renders error state correctly 1`] = `
       class="cdr-form-error"
       id="renders-error"
       role="status"
-      tabindex="0"
     >
       <span
         class="cdr-form-error__icon"

--- a/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
+++ b/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
@@ -18,7 +18,7 @@ exports[`CdrInput renders correctly 1`] = `
     <!--v-if-->
   </div>
   <div
-    class="cdr-label-standalone__input-wrap cdr-label-standalone__input--spacing"
+    class="cdr-label-standalone__input-wrap cdr-label-standalone__input-spacing"
   >
     
     <div
@@ -68,7 +68,7 @@ exports[`CdrInput renders error state correctly 1`] = `
     <!--v-if-->
   </div>
   <div
-    class="cdr-label-standalone__input-wrap cdr-label-standalone__input--spacing"
+    class="cdr-label-standalone__input-wrap cdr-label-standalone__input-spacing"
   >
     
     <div
@@ -159,7 +159,7 @@ exports[`CdrInput renders number input correctly 1`] = `
     <!--v-if-->
   </div>
   <div
-    class="cdr-label-standalone__input-wrap cdr-label-standalone__input--spacing"
+    class="cdr-label-standalone__input-wrap cdr-label-standalone__input-spacing"
   >
     
     <div

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -381,7 +381,7 @@ export default {
     },
   },
   mounted() {
-    this.setBackground(this.$router.currentRoute.query.background);
+    this.setBackground(this.$route.query.background);
   },
   methods: {
     validate() {

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -181,73 +181,7 @@
         </cdr-link>
       </template>
     </cdr-input>
-<cdr-input
-      class="demo-input"
-      :required="true"
-      v-model="megaModel"
-      :error="megaErr"
-      error-role="alert"
-      id="inputWithError"
-      label="Everything at the same time, alert validation"
-      @blur="megaErr = false"
-      size="large"
-    >
-      <icon-map #pre-icon />
-      <template #helper-text-top>
-        <span id="topHelp">Hey im on top of the input!</span>
-      </template>
-      <template #helper-text-bottom>
-        <span id="bottomHelp">Hey im below the input!</span>
-      </template>
-      <template #info>
-        <cdr-link
-          href="#baz"
-          modifier="standalone"
-        >
-          Hey im also on top of the input!
-        </cdr-link>
-      </template>
-      <template #info-action>
-        <cdr-link
-          tag="button"
-          type="button"
-        >
-          <span class="sr-only">I trigger some sort of action!</span>
-          <icon-check-stroke inherit-color />
-        </cdr-link>
-      </template>
-      <template #post-icon>
-        <cdr-tooltip
-          class="cdr-input__button"
-          id="mega-tooltip"
-        >
-          <cdr-button
-            #trigger
-            :icon-only="true"
-            @click="megaErr = 'you have five minutes to fix this'"
-            size="large"
-            aria-label="Click me to cause an error"
-          >
-            <icon-x-stroke />
-          </cdr-button>
-          I put the input into an error state!
-        </cdr-tooltip>
-        <cdr-popover
-          class="cdr-input__button"
-          id="mega-popover"
-        >
-          <cdr-button
-            #trigger
-            :icon-only="true"
-            size="large"
-            aria-label="Hello"
-          >
-            <icon-information-stroke />
-          </cdr-button>
-          Hey What's Up?
-        </cdr-popover>
-      </template>
-    </cdr-input>
+
     <cdr-input
       class="demo-input"
       v-model="helperValidationModel"
@@ -443,11 +377,11 @@ export default {
   },
   watch: {
     $route(to) {
-      this.setBackground("primary");
+       this.setBackground(to.query.background);
     },
   },
   mounted() {
-    this.setBackground("primary");
+    this.setBackground(this.$router.currentRoute.query.background);
   },
   methods: {
     validate() {

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -90,7 +90,7 @@
       type="email"
       :background="backgroundColor"
     >
-      <template slot="info-action">
+      <template #info-action>
         <cdr-link
           tag="button"
           type="button"
@@ -99,17 +99,17 @@
           <span class="sr-only">Information!</span>
         </cdr-link>
       </template>
-      <template slot="pre-icon">
+      <template #pre-icon>
         <cdr-icon
           use="#twitter"
         />
       </template>
-      <template slot="post-icon">
+      <template #post-icon>
         <cdr-icon
           use="#check-lg"
         />
       </template>
-      <template slot="helper-text">
+      <template #helper-text>
         This is helper text. Input length: {{ requiredWithIcons.length }}
       </template>
     </cdr-input>
@@ -125,19 +125,19 @@
         autocomplete="username"
         :background="backgroundColor"
       >
-        <template slot="pre-icon">
+        <template #pre-icon>
           <cdr-icon
             use="#twitter"
           />
         </template>
-        <template slot="post-icon">
+        <template #post-icon>
           <cdr-tooltip
             class="cdr-input__button"
             id="input-tooltip"
           >
             <cdr-button
               :icon-only="true"
-              slot="trigger"
+              #trigger
               aria-label="navigate"
             >
               <icon-map />
@@ -172,7 +172,7 @@
         <span id="errorMessage">you have added too many characters, remove some</span>
       </template>
 
-      <template slot="info">
+      <template #info>
         <cdr-link
           modifier="standalone"
           href="#/inputs"
@@ -181,7 +181,73 @@
         </cdr-link>
       </template>
     </cdr-input>
-
+<cdr-input
+      class="demo-input"
+      :required="true"
+      v-model="megaModel"
+      :error="megaErr"
+      error-role="alert"
+      id="inputWithError"
+      label="Everything at the same time, alert validation"
+      @blur="megaErr = false"
+      size="large"
+    >
+      <icon-map #pre-icon />
+      <template #helper-text-top>
+        <span id="topHelp">Hey im on top of the input!</span>
+      </template>
+      <template #helper-text-bottom>
+        <span id="bottomHelp">Hey im below the input!</span>
+      </template>
+      <template #info>
+        <cdr-link
+          href="#baz"
+          modifier="standalone"
+        >
+          Hey im also on top of the input!
+        </cdr-link>
+      </template>
+      <template #info-action>
+        <cdr-link
+          tag="button"
+          type="button"
+        >
+          <span class="sr-only">I trigger some sort of action!</span>
+          <icon-check-stroke inherit-color />
+        </cdr-link>
+      </template>
+      <template #post-icon>
+        <cdr-tooltip
+          class="cdr-input__button"
+          id="mega-tooltip"
+        >
+          <cdr-button
+            #trigger
+            :icon-only="true"
+            @click="megaErr = 'you have five minutes to fix this'"
+            size="large"
+            aria-label="Click me to cause an error"
+          >
+            <icon-x-stroke />
+          </cdr-button>
+          I put the input into an error state!
+        </cdr-tooltip>
+        <cdr-popover
+          class="cdr-input__button"
+          id="mega-popover"
+        >
+          <cdr-button
+            #trigger
+            :icon-only="true"
+            size="large"
+            aria-label="Hello"
+          >
+            <icon-information-stroke />
+          </cdr-button>
+          Hey What's Up?
+        </cdr-popover>
+      </template>
+    </cdr-input>
     <cdr-input
       class="demo-input"
       v-model="helperValidationModel"
@@ -195,7 +261,7 @@
         <span id="errorMessage">this error comes from slots, and will override any errors from props</span>
       </template>
 
-      <template slot="info">
+      <template #info>
         <cdr-link
           modifier="standalone"
           href="#/inputs"
@@ -235,14 +301,14 @@
       @blur="megaErr = false"
       size="large"
     >
-      <icon-map slot="pre-icon" />
-      <template slot="helper-text-top">
+      <icon-map #pre-icon />
+      <template #helper-text-top>
         <span id="topHelp">Hey im on top of the input!</span>
       </template>
-      <template slot="helper-text-bottom">
+      <template #helper-text-bottom>
         <span id="bottomHelp">Hey im below the input!</span>
       </template>
-      <template slot="info">
+      <template #info>
         <cdr-link
           href="#baz"
           modifier="standalone"
@@ -250,7 +316,7 @@
           Hey im also on top of the input!
         </cdr-link>
       </template>
-      <template slot="info-action">
+      <template #info-action>
         <cdr-link
           tag="button"
           type="button"
@@ -259,13 +325,13 @@
           <icon-check-stroke inherit-color />
         </cdr-link>
       </template>
-      <template slot="post-icon">
+      <template #post-icon>
         <cdr-tooltip
           class="cdr-input__button"
           id="mega-tooltip"
         >
           <cdr-button
-            slot="trigger"
+            #trigger
             :icon-only="true"
             @click="megaErr = 'you have five minutes to fix this'"
             size="large"
@@ -280,7 +346,7 @@
           id="mega-popover"
         >
           <cdr-button
-            slot="trigger"
+            #trigger
             :icon-only="true"
             size="large"
             aria-label="Hello"
@@ -377,29 +443,29 @@ export default {
   },
   watch: {
     $route(to) {
-      this.setBackground(to.query.background);
+      this.setBackground("primary");
     },
   },
   mounted() {
-    this.setBackground(this.$router.currentRoute.query.background);
+    this.setBackground("primary");
   },
   methods: {
     validate() {
       this.helperValidationError = this.helperValidationModel.length > 4;
     },
     onMasterInput(value, e) {
-      console.log('On Master Input value = ', value, ' e = ', e); // eslint-disable-line
-      this.defaultModel = value;
-      this.requiredModel = value;
-      this.optionalModel = value;
-      this.hiddenModel = value;
-      this.disabledModel = value;
-      this.formWithButtons = value;
-      this.requiredWithIcons = value;
-      this.helperValidationModel = value;
-      this.multiRowModel = value;
-      this.sizeModel = value;
-      this.megaModel = value;
+      console.log('On Master Input value = ', this.masterModel, ' e = ', e); // eslint-disable-line
+      this.defaultModel = this.masterModel;
+      this.requiredModel = this.masterModel;
+      this.optionalModel = this.masterModel;
+      this.hiddenModel = this.masterModel;
+      this.disabledModel = this.masterModel;
+      this.formWithButtons = this.masterModel;
+      this.requiredWithIcons = this.masterModel;
+      this.helperValidationModel = this.masterModel;
+      this.multiRowModel = this.masterModel;
+      this.sizeModel = this.masterModel;
+      this.megaModel = this.masterModel;
     },
     setBackground(background) {
       switch (background) {

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -169,7 +169,7 @@
       </template>
 
       <template #error>
-        <span id="errorMessage">you have added too many characters, remove some</span>
+        <span>you have added too many characters, remove some</span>
       </template>
 
       <template #info>
@@ -192,7 +192,7 @@
     >
 
       <template #error>
-        <span id="errorMessage">this error comes from slots, and will override any errors from props</span>
+        <span>this error comes from slots, and will override any errors from props</span>
       </template>
 
       <template #info>

--- a/src/components/labelStandalone/CdrLabelStandalone.vue
+++ b/src/components/labelStandalone/CdrLabelStandalone.vue
@@ -76,7 +76,7 @@ export default defineComponent({
     const srOnlyLabelClass = computed(() => props.hideLabel
       && 'cdr-label-standalone__label--sr-only');
     const inputSpacingClass = computed(() => (!props.hideLabel || hasHelper || hasInfo)
-      && 'cdr-label-standalone__input--spacing');
+      && 'cdr-label-standalone__input-spacing');
     return {
       style: useCssModule(),
       mapClasses,

--- a/src/components/labelStandalone/CdrLabelStandalone.vue
+++ b/src/components/labelStandalone/CdrLabelStandalone.vue
@@ -8,7 +8,6 @@
         {{ label }}{{ required || optional ? '' : '' }}
         <span
           v-if="required"
-          aria-label="required"
         >*</span>
 
         <span

--- a/src/components/labelStandalone/__tests__/__snapshots__/CdrLabelStandalone.spec.js.snap
+++ b/src/components/labelStandalone/__tests__/__snapshots__/CdrLabelStandalone.spec.js.snap
@@ -29,7 +29,7 @@ exports[`CdrFormLabelStandalone matches snapshot 1`] = `
     </span>
   </div>
   <div
-    class="cdr-label-standalone__input-wrap cdr-label-standalone__input--spacing"
+    class="cdr-label-standalone__input-wrap cdr-label-standalone__input-spacing"
   >
     
     

--- a/src/components/labelStandalone/__tests__/__snapshots__/CdrLabelStandalone.spec.js.snap
+++ b/src/components/labelStandalone/__tests__/__snapshots__/CdrLabelStandalone.spec.js.snap
@@ -12,9 +12,7 @@ exports[`CdrFormLabelStandalone matches snapshot 1`] = `
       for="test"
     >
       Label Test 
-      <span
-        aria-label="required"
-      >
+      <span>
         *
       </span>
     </label>

--- a/src/components/select/__tests__/__snapshots__/CdrSelect.spec.js.snap
+++ b/src/components/select/__tests__/__snapshots__/CdrSelect.spec.js.snap
@@ -18,7 +18,7 @@ exports[`cdrSelect renders correctly 1`] = `
     <!--v-if-->
   </div>
   <div
-    class="cdr-label-standalone__input-wrap cdr-label-standalone__input--spacing"
+    class="cdr-label-standalone__input-wrap cdr-label-standalone__input-spacing"
   >
     
     <div
@@ -85,7 +85,7 @@ exports[`cdrSelect renders error state correctly 1`] = `
     <!--v-if-->
   </div>
   <div
-    class="cdr-label-standalone__input-wrap cdr-label-standalone__input--spacing"
+    class="cdr-label-standalone__input-wrap cdr-label-standalone__input-spacing"
   >
     
     <div

--- a/src/components/select/__tests__/__snapshots__/CdrSelect.spec.js.snap
+++ b/src/components/select/__tests__/__snapshots__/CdrSelect.spec.js.snap
@@ -135,7 +135,6 @@ exports[`cdrSelect renders error state correctly 1`] = `
       class="cdr-form-error"
       id="renders-error"
       role="status"
-      tabindex="0"
     >
       <span
         class="cdr-form-error__icon"

--- a/src/utils/uid.js
+++ b/src/utils/uid.js
@@ -1,0 +1,8 @@
+/**
+ * Quickly generates a unique id string.
+ */
+
+export default function uid() {
+    let uid = Math.floor((1 + Math.random()) * 0x1000000).toString(16).substring(1);
+    return `cdr-id-${uid}`
+}

--- a/src/utils/uid.js
+++ b/src/utils/uid.js
@@ -3,6 +3,6 @@
  */
 
 export default function uid() {
-    let uid = Math.floor((1 + Math.random()) * 0x1000000).toString(16).substring(1);
+    const uid = Math.floor((1 + Math.random()) * 0x1000000).toString(16).substring(1);
     return `cdr-id-${uid}`
 }


### PR DESCRIPTION
- Refactor CdrInput to use <script setup> syntax. 
- Fixed v-model issue by referencing a new computed ‘inputModel’ with its own custom getter and setter. 
- Ensured all fallthrough attributes except class get applied to the input element. The class attribute is bound to the outermost element.
- Added a uid module to provide a unique id for each component should an id not be provided by the user. 
- Fixed some implementations issue on the CdrInput example page.
- Fixed a typo in CdrLabelStandalone.
