### PR TITLE
refactor(cdr-select): refactor cdr-select to use Vue 3 <script setup>…

### DIFF
--- a/src/components/select/CdrSelect.vue
+++ b/src/components/select/CdrSelect.vue
@@ -7,7 +7,6 @@ export default {
 
 <script setup>
 import { useCssModule, useSlots, useAttrs, computed, defineEmits } from 'vue';
-import toArray from 'lodash/toArray';
 import IconCaretDown from '../icon/comps/caret-down';
 import CdrLabelStandalone from '../labelStandalone/CdrLabelStandalone';
 import CdrFormError from '../formError/CdrFormError';

--- a/src/components/select/CdrSelect.vue
+++ b/src/components/select/CdrSelect.vue
@@ -1,6 +1,138 @@
+<script>
+export default {
+  inheritAttrs: false,
+  customOptions: {}
+}
+</script>
+
+<script setup>
+import { useCssModule, useSlots, useAttrs, computed, defineEmits } from 'vue';
+import toArray from 'lodash/toArray';
+import IconCaretDown from '../icon/comps/caret-down';
+import CdrLabelStandalone from '../labelStandalone/CdrLabelStandalone';
+import CdrFormError from '../formError/CdrFormError';
+import sizeProps from '../../props/size';
+import backgroundProps from '../../props/background';
+import mapClasses from '../../utils/mapClasses';
+import uid from '../../utils/uid';
+const emit = defineEmits(['update:modelValue'])
+const props = defineProps({
+  /**
+   * `id` for the select that is mapped to the label `for` attribute. If one is not provided, it will be generated.
+  */
+  id: {
+    type: String,
+  },
+  /**
+   * Label text. This is required for a11y even if hiding the label with `hideLabel`.
+  */
+  label: {
+    type: String,
+    required: true,
+  },
+  /**
+   * Removes the label element but sets the select `aria-label` to `label` text for a11y.
+  */
+  hideLabel: Boolean,
+  /**
+   * Adds an option that is disabled and selected by default to serve as a `placeholder` for the select.
+  */
+  prompt: String,
+  /**
+   * Build options programatically with data. Array of objects [{ text: String, value: String}] to give greater control. Array of strings ['String'] for simpler setup (value and text will be the same).
+  */
+  options: {
+    type: Array,
+  },
+  // Set which background type the select renders on
+  background: backgroundProps,
+  size: sizeProps,
+  // Set error styling
+  error: {
+    type: [Boolean, String],
+    default: false,
+  },
+  /**
+  * Override the error message role, default is `status`.
+  */
+  errorRole: {
+    type: String,
+    required: false,
+    default: 'status',
+  },
+  modelValue: {
+    type: [String, Number, Boolean, Object, Array, Symbol, Function],
+  },
+  disabled: Boolean,
+  required: Boolean,
+  optional: Boolean,
+  multiple: Boolean,
+  multipleSize: Number,
+})
+const slots = useSlots();
+const attrs = useAttrs();
+const baseClass = 'cdr-select';
+const hasHelper = slots['helper-text'];
+const hasInfo = slots.info;
+const hasInfoAction = slots['info-action'];
+const hasPreIcon = slots['pre-icon'];
+const uniqueId = props.id ? props.id : uid();
+
+
+const multipleClass = computed(() => props.multiple && 'cdr-select--multiple');
+const promptClass = computed(() => !props.modelValue && 'cdr-select__prompt');
+const multilineClass = computed(() => props.rows > 1 && 'cdr-select--multiline');
+const preIconClass = computed(() => hasPreIcon && 'cdr-select--preicon');
+const errorClass = computed(() => props.error && 'cdr-select--error');
+const backgroundClass = computed(() => `cdr-select--${props.background}`);
+const sizeClass = computed(() => props.size && `${baseClass}--${props.size}`);
+const caretDisabledClass = computed(() => props.disabled && 'cdr-select__caret--disabled');
+
+const describedby = computed(() => {
+  return [
+    slots['helper-text'] ? `${uniqueId}-helper-text-top` : '',
+    attrs['aria-describedby'],
+  ].filter((x) => x).join(' ');
+})
+
+// TODO: refactor, would be much clearer as a 1-2 liner
+const computedOpts = computed(() => {
+  const optsArr = [];
+  if (props.options) {
+    props.options.forEach((o) => {
+      const optObj = {};
+      let text = '';
+      let val = '';
+      if (typeof o === 'string') {
+        text = o;
+        val = o;
+      } else {
+        const { text: t, value: v } = o;
+        text = t;
+        val = v;
+      }
+      optObj.text = text;
+      optObj.value = val;
+      optsArr.push(optObj);
+    });
+  }
+  return optsArr;
+});
+
+const selectModel = computed({
+  get() {
+    return props.modelValue
+  },
+  set(newValue) {
+    emit('update:modelValue', newValue)
+  }
+})
+const style = useCssModule();
+</script>
+
 <template>
   <cdr-label-standalone
-    :for-id="id"
+    :for-id="uniqueId"
     :label="label"
     :hide-label="hideLabel"
     :required="required"
@@ -30,6 +162,7 @@
       </span>
 
       <select
+        :id="uniqueId"
         :class="mapClasses(style,
           baseClass,
           sizeClass,
@@ -39,21 +172,17 @@
           errorClass,
           preIconClass,
         )"
-        :id="id"
         :multiple="multiple"
         :size="multipleSize"
         :disabled="disabled"
         :aria-required="required || null"
 
         :aria-invalid="!!error || null"
-        :aria-errormessage="(!!error && `${id}-error`) || null"
+        :aria-errormessage="(!!error && `${uniqueId}-error`) || null"
         v-bind="$attrs"
         :aria-describedby="describedby || null"
         :value="modelValue"
-        @change="$emit('update:modelValue', multiple
-          ? processMultiple($event.target.options)
-          : $event.target.value)
-        "
+        v-model="selectModel"
       >
         <option
           v-if="prompt"
@@ -84,7 +213,7 @@
       <cdr-form-error
         :error="error"
         :role="errorRole"
-        :id="`${id}-error`"
+        :id="`${uniqueId}-error`"
         v-if="error"
       >
         <template #error>
@@ -94,158 +223,6 @@
     </template>
   </cdr-label-standalone>
 </template>
-
-<script>
-import { defineComponent, useCssModule, computed } from 'vue';
-import toArray from 'lodash/toArray';
-import IconCaretDown from '../icon/comps/caret-down';
-import CdrLabelStandalone from '../labelStandalone/CdrLabelStandalone';
-import CdrFormError from '../formError/CdrFormError';
-import sizeProps from '../../props/size';
-import backgroundProps from '../../props/background';
-import mapClasses from '../../utils/mapClasses';
-
-export default defineComponent({
-  name: 'CdrSelect',
-  components: {
-    IconCaretDown,
-    CdrLabelStandalone,
-    CdrFormError,
-  },
-  inheritAttrs: false,
-  props: {
-    /**
-     * `id` for the select that is mapped to the label `for` attribute. If one is not provided, it will be generated.
-    */
-    id: {
-      type: String,
-      required: true,
-    },
-    /**
-     * Label text. This is required for a11y even if hiding the label with `hideLabel`.
-    */
-    label: {
-      type: String,
-      required: true,
-    },
-    /**
-     * Removes the label element but sets the select `aria-label` to `label` text for a11y.
-    */
-    hideLabel: Boolean,
-    /**
-     * Adds an option that is disabled and selected by default to serve as a `placeholder` for the select.
-    */
-    prompt: String,
-    /**
-     * Build options programatically with data. Array of objects [{ text: String, value: String}] to give greater control. Array of strings ['String'] for simpler setup (value and text will be the same).
-    */
-    options: {
-      type: Array,
-    },
-    // Set which background type the select renders on
-    background: backgroundProps,
-    size: sizeProps,
-    // Set error styling
-    error: {
-      type: [Boolean, String],
-      default: false,
-    },
-    /**
-    * Override the error message role, default is `status`.
-    */
-    errorRole: {
-      type: String,
-      required: false,
-      default: 'status',
-    },
-    modelValue: {
-      type: [String, Number, Boolean, Object, Array, Symbol, Function],
-    },
-    disabled: Boolean,
-    required: Boolean,
-    optional: Boolean,
-    multiple: Boolean,
-    multipleSize: Number,
-  },
-  setup(props, ctx) {
-    const baseClass = 'cdr-select';
-
-    const hasHelper = ctx.slots['helper-text'];
-    const hasInfo = ctx.slots.info;
-    const hasInfoAction = ctx.slots['info-action'];
-    const hasPreIcon = ctx.slots['pre-icon'];
-
-
-    const multipleClass = computed(() => props.multiple && 'cdr-select--multiple');
-
-    const promptClass = computed(() => !props.modelValue && 'cdr-select--preicon');
-    const multilineClass = computed(() => props.rows > 1 && 'cdr-select--multiline');
-    const preIconClass = computed(() => hasPreIcon && 'cdr-select--preicon');
-    const errorClass = computed(() => props.error && 'cdr-select--error');
-    const backgroundClass = computed(() => `cdr-select--${props.background}`);
-    const sizeClass = computed(() => props.size && `${baseClass}--${props.size}`);
-    const caretDisabledClass = computed(() => props.disabled && 'cdr-select__caret--disabled');
-
-
-    const describedby = computed(() => {
-      return [
-        ctx.slots['helper-text'] ? `${props.id}-helper-text-top` : '',
-        ctx.attrs['aria-describedby'],
-      ].filter((x) => x).join(' ');
-    })
-
-    // TODO: refactor, would be much clearer as a 1-2 liner
-    const computedOpts = computed(() => {
-      const optsArr = [];
-      if (props.options) {
-        props.options.forEach((o) => {
-          const optObj = {};
-          let text = '';
-          let val = '';
-          if (typeof o === 'string') {
-            text = o;
-            val = o;
-          } else {
-            const { text: t, value: v } = o;
-            text = t;
-            val = v;
-          }
-          optObj.text = text;
-          optObj.value = val;
-          optsArr.push(optObj);
-        });
-      }
-      return optsArr;
-    });
-
-    const processMultiple = (options) => toArray(options)
-      .filter((o) => o.selected === true)
-      .map((o) => o.value);
-
-    return {
-      style: useCssModule(),
-      baseClass,
-      computedOpts,
-      hasHelper,
-      hasInfo,
-      hasInfoAction,
-      hasPreIcon,
-
-      describedby,
-      processMultiple,
-      multipleClass,
-      promptClass,
-      multilineClass,
-      preIconClass,
-      errorClass,
-      backgroundClass,
-      sizeClass,
-      caretDisabledClass,
-      mapClasses,
-    };
-  },
-});
-</script>
 
 <style lang="scss" module src="./styles/CdrSelect.module.scss">
 </style>

--- a/src/components/select/__tests__/__snapshots__/CdrSelect.spec.js.snap
+++ b/src/components/select/__tests__/__snapshots__/CdrSelect.spec.js.snap
@@ -26,7 +26,7 @@ exports[`cdrSelect renders correctly 1`] = `
     >
       <!--v-if-->
       <select
-        class="cdr-select cdr-select--medium cdr-select--preicon cdr-select--primary"
+        class="cdr-select cdr-select--medium cdr-select__prompt cdr-select--primary"
         id="renders"
       >
         <!--v-if-->
@@ -95,7 +95,7 @@ exports[`cdrSelect renders error state correctly 1`] = `
       <select
         aria-errormessage="renders-error"
         aria-invalid="true"
-        class="cdr-select cdr-select--medium cdr-select--preicon cdr-select--primary cdr-select--error"
+        class="cdr-select cdr-select--medium cdr-select__prompt cdr-select--primary cdr-select--error"
         id="renders"
       >
         <!--v-if-->

--- a/src/components/select/examples/Selects.vue
+++ b/src/components/select/examples/Selects.vue
@@ -139,11 +139,11 @@
 
       prompt="Choose One"
     >
-      <template slot="helper-text">
+      <template #helper-text>
         This is helper text.
       </template>
 
-      <template slot="info">
+      <template #info>
         <cdr-link
           href="#/selects"
           modifier="standalone"
@@ -164,7 +164,7 @@
 
       prompt="Choose One"
     >
-      <template slot="info">
+      <template #info>
         <cdr-link
           href="#/selects"
           modifier="standalone"
@@ -185,7 +185,7 @@
 
       prompt="Choose One"
     >
-      <template slot="info-action">
+      <template #info-action>
         <cdr-link
           tag="button"
           type="button"
@@ -207,7 +207,7 @@
 
       prompt="Choose One"
     >
-      <template slot="pre-icon">
+      <template #pre-icon>
         <icon-lock-locked-stroke />
       </template>
     </cdr-select>
@@ -223,9 +223,10 @@
       aria-describedby="statusTest"
 
       prompt="Choose One"
-      :error="true"
+      :error="this.preIconModelError"
+      @change="validatePreIconModel"
     >
-      <template slot="error">
+      <template #error>
         <span id="statusTest">error message goes here</span>
       </template>
     </cdr-select>
@@ -241,12 +242,33 @@
       aria-describedby="alertTest"
 
       prompt="Choose One"
-      :error="true"
+      :error="this.preIconModel2Error"
+      @change="validatePreIconModel2"
     >
-      <template slot="error">
+      <template #error>
         <span id="alertTest">Alert error message goes here</span>
       </template>
     </cdr-select>
+    <hr class="icon-hr">
+
+    <!-- Nested Options -->
+    <cdr-select
+      v-model="nested"
+      :background="backgroundColor"
+      label="Nested Options"
+    >
+      <optgroup label="bread">
+        <option value="rye">rye</option>
+        <option value="sourdough">sourdough</option>
+        <option value="wheat">wheat</option>
+      </optgroup>
+      <optgroup label="toppings">
+        <option value="provolone">provolone</option>
+        <option value="peppers">peppers</option>
+        <option value="gabagool">gabagool</option>
+      </optgroup>
+    </cdr-select>
+    <cdr-text>Selected Value: {{ nested }}</cdr-text>
     <hr class="icon-hr">
 
     <!-- Large Select Example -->
@@ -311,7 +333,6 @@
       :options="multiple2Data"
     />
     <cdr-text>Selected Values: {{ multiple2 }}</cdr-text>
-    <hr class="icon-hr">
   </div>
 </template>
 
@@ -335,6 +356,9 @@ export default {
       infoIconModel: '',
       preIconModel: '',
       preIconModel2: '',
+      preIconModelError: true,
+      preIconModel2Error: true,
+      nested:'',
       multiple: ['1', '2'],
       multiple2: ['-1'],
       multiple2Data: ['a', 'b', 'c', 'd'],
@@ -343,15 +367,21 @@ export default {
   },
   watch: {
     $route(to) {
-      this.setBackground(to.query.background);
+       this.setBackground(to.query.background);
     },
   },
   mounted() {
-    this.setBackground(this.$router.currentRoute.query.background);
+    this.setBackground(this.$route.query.background);
   },
   methods: {
     inputEventHandler(selectedValue, event) {
       console.log('input Event event = ', event, ' selectedValue = ', selectedValue); // eslint-disable-line
+    },
+    validatePreIconModel() {
+      this.preIconModelError = !this.preIconModel.length;
+    },
+    validatePreIconModel2() {
+      this.preIconModel2Error = !this.preIconModel2.length;
     },
     inputChange(selectedValue, event) {
       console.log('change Event event = ', event, ' selectedValue = ', selectedValue); // eslint-disable-line


### PR DESCRIPTION
… syntax

- Add v-model bound to computed selectModel value.
- Add unique id. 
- Remove toArray import from lodash.
- Remove function which computed selected options for a multiple select (v-model takes care of this).
- Fix styling issues with incorrect classes being applied.