### PR TITLE
fix(cdr-popover): fix popover focus bug and custom trigger open state…

### DIFF
--- a/src/components/popover/CdrPopover.vue
+++ b/src/components/popover/CdrPopover.vue
@@ -108,10 +108,10 @@
     lastActive = activeElement;
     isOpen.value = true;
     emit('opened', e);
-    nextTick(() => {
+    setTimeout(()=>{
       const tabbables = tabbable(popupEl.value.$el);
       if (tabbables[0]) tabbables[0].focus();
-    });
+    }, 50)
   }
 
   const closePopover = (e) => {

--- a/src/components/popover/examples/Popover.vue
+++ b/src/components/popover/examples/Popover.vue
@@ -121,8 +121,7 @@
         :open="open"
         content-class="popover-override"
         id="popover-custom-test"
-        @opened="popupHandler"
-        @closed="popupHandler"
+        @closed="closedCustomHandler"
       >
         <cdr-text>
           This is an example of a popover where the trigger is not passed into the component
@@ -157,6 +156,10 @@ export default {
   },
   methods: {
     popupHandler(e) {
+      console.log(e);
+    },
+    closedCustomHandler(e) {
+      this.open = false;
       console.log(e);
     },
   },


### PR DESCRIPTION
… bug

Added longer timeout to fix focus issue. Added custom handler to the "close" event to ensure that
the open state wasn't set to true after the popover with the custom trigger closed