### PR TITLE
Image container fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rei/cedar",
-  "version": "13.0.0-next.1",
+  "version": "13.0.0-next.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rei/cedar",
-      "version": "13.0.0-next.1",
+      "version": "13.0.0-next.2",
       "license": "MIT",
       "dependencies": {
         "core-js": "^3.22.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "13.0.0-next.1",
+  "version": "13.0.0-next.2",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/components/image/CdrImg.vue
+++ b/src/components/image/CdrImg.vue
@@ -2,7 +2,7 @@
   <div
     v-if="ratio"
     :style="ratioObject"
-    :class="style[ratioClass]"
+    :class="[style[ratioClass], containerClass]"
   >
     <img
       :style="cropObject"
@@ -85,6 +85,10 @@ const props = defineProps({
   cover: {
     type: Boolean,
   },
+    /**
+   * Adds a custom class to the cdr-img__ratio container div
+   */
+  containerClass: String,
   /**
    * Sets a border radius to an element {square, top, right, bottom, left}
    */

--- a/src/components/image/examples/demos/Cropping.vue
+++ b/src/components/image/examples/demos/Cropping.vue
@@ -211,7 +211,7 @@ export default {
   components: Components,
   data() {
     return {
-      testImage: 'test-image.png',
+      testImage: '/src/dev/static/cedar-1920x1080.jpg',
     };
   },
 };

--- a/src/components/image/examples/demos/Mods.vue
+++ b/src/components/image/examples/demos/Mods.vue
@@ -9,7 +9,7 @@
           Responsive
         </cdr-text>
         <cdr-img
-          class="cdr-img-test"
+          container-class="cdr-img-test"
           ratio="4-3"
           modifier="responsive"
           loading="lazy"
@@ -17,7 +17,7 @@
           src="/src/dev/static/cedar-200x200.jpg"
         />
         <cdr-img
-          class="cdr-img-test"
+          container-class="cdr-img-test"
           modifier="responsive"
           alt="standard responsive"
           src="/src/dev/static/cedar-200x200.jpg"
@@ -28,20 +28,20 @@
           Rounded
         </cdr-text>
         <cdr-img
-          class="cdr-img-test"
+          container-class="cdr-img-test"
           ratio="4-3"
           radius="rounded"
           alt="ratio rounded"
           src="/src/dev/static/cedar-200x200.jpg"
         />
         <cdr-img
-          class="cdr-img-test"
+          container-class="cdr-img-test"
           radius="rounded"
           alt="landscape rounded"
           src="/src/dev/static/cedar-350x150.jpg"
         />
         <cdr-img
-          class="cdr-img-test"
+          container-class="cdr-img-test"
           radius="rounded"
           alt="square rounded"
           src="/src/dev/static/cedar-200x200.jpg"
@@ -52,20 +52,20 @@
           circle
         </cdr-text>
         <cdr-img
-          class="cdr-img-test"
+          container-class="cdr-img-test"
           ratio="4-3"
           radius="circle"
           alt="ratio circle"
           src="/src/dev/static/cedar-200x200.jpg"
         />
         <cdr-img
-          class="cdr-img-test"
+          container-class="cdr-img-test"
           radius="circle"
           alt="landscape circle"
           src="/src/dev/static/cedar-350x150.jpg"
         />
         <cdr-img
-          class="cdr-img-test"
+          container-class="cdr-img-test"
           radius-="circle"
           alt="square circle"
           src="/src/dev/static/cedar-200x200.jpg"

--- a/src/components/image/examples/demos/Ratios.vue
+++ b/src/components/image/examples/demos/Ratios.vue
@@ -5,7 +5,7 @@
         Square
       </cdr-text>
       <cdr-img
-        class="cdr-img-test"
+        container-container-class="cdr-img-test"
         ratio="square"
         alt="ratio square"
         src="/src/dev/static/cedar-300x100.jpg"
@@ -16,12 +16,11 @@
         Auto (min-height)
       </cdr-text>
       <cdr-img
-        class="cdr-img-test"
+        container-class="cdr-img-test auto"
         ratio="auto"
         crop="center"
         cover
         alt="ratio auto"
-        style="min-height: 100px"
         src="/src/dev/static/cedar-300x100.jpg"
       />
     </div>
@@ -32,12 +31,11 @@
       </cdr-text>
       <div style="width: 100%; height: 100%">
         <cdr-img
-          class="cdr-img-test"
+          container-class="cdr-img-test auto-fill"
           ratio="auto"
           crop="center"
           cover
           alt="ratio auto"
-          style="width: 100%; height: 100%;"
           src="/src/dev/static/cedar-300x100.jpg"
         />
       </div>
@@ -49,7 +47,7 @@
       </cdr-text>
       <cdr-grid style="grid-template-columns: 1fr 2fr">
         <cdr-img
-          class="cdr-img-test"
+          container-class="cdr-img-test"
           ratio="auto"
           crop="center"
           cover
@@ -66,7 +64,7 @@
         1-2
       </cdr-text>
       <cdr-img
-        class="cdr-img-test"
+        container-class="cdr-img-test"
         ratio="1-2"
         alt="ratio 1-2"
         src="/src/dev/static/cedar-300x100.jpg"
@@ -77,7 +75,7 @@
         2-3
       </cdr-text>
       <cdr-img
-        class="cdr-img-test"
+        container-class="cdr-img-test"
         ratio="2-3"
         alt="ratio 2-3"
         src="/src/dev/static/cedar-300x100.jpg"
@@ -88,7 +86,7 @@
         3-4
       </cdr-text>
       <cdr-img
-        class="cdr-img-test"
+        container-class="cdr-img-test"
         ratio="3-4"
         alt="ratio 3-4"
         src="/src/dev/static/cedar-300x100.jpg"
@@ -99,7 +97,7 @@
         9-16
       </cdr-text>
       <cdr-img
-        class="cdr-img-test"
+        container-class="cdr-img-test"
         ratio="9-16"
         alt="ratio 9-16"
         src="/src/dev/static/cedar-300x100.jpg"
@@ -110,7 +108,7 @@
         2-1
       </cdr-text>
       <cdr-img
-        class="cdr-img-test"
+        container-class="cdr-img-test"
         ratio="2-1"
         alt="ratio 2-1"
         src="/src/dev/static/cedar-300x100.jpg"
@@ -121,7 +119,7 @@
         3-2
       </cdr-text>
       <cdr-img
-        class="cdr-img-test"
+        container-class="cdr-img-test"
         ratio="3-2"
         alt="ratio 3-2"
         src="/src/dev/static/cedar-300x100.jpg"
@@ -132,7 +130,7 @@
         4-3
       </cdr-text>
       <cdr-img
-        class="cdr-img-test"
+        container-class="cdr-img-test"
         ratio="4-3"
         alt="ratio 4-3"
         src="/src/dev/static/cedar-300x100.jpg"
@@ -143,7 +141,7 @@
         16-9
       </cdr-text>
       <cdr-img
-        class="cdr-img-test"
+        container-class="cdr-img-test"
         ratio="16-9"
         alt="ratio 16-9"
         src="/src/dev/static/cedar-300x100.jpg"
@@ -164,5 +162,11 @@ export default {
 <style>
   .cdr-img-test {
     background-color: lightblue;
+  }
+  .auto {
+    min-height: 100px
+  }
+  .auto-fill {
+    width: 100%; height: 100%;
   }
 </style>


### PR DESCRIPTION
CdrImg has always bound any pass-through attributes to the <img> element itself. This allows a consumer to pass something like `loading="lazy"`. 

Vue 2 did not include `class` or `style` attributes as part of the `$attrs` object, so they would be treated as default attribute pass-throughs and be applied to the parent element of CdrImg. The attribute object has been changed in Vue 3 to include class and style and thus they now pass down to the img element as weill.
https://v3-migration.vuejs.org/breaking-changes/attrs-includes-class-style.html

Overall this leads to a more consistent experience, however many of our consumers relied on the interaction of passing a class to the parent element, particularly when being used with a ratio (which adds a wrapping ratio container div).

This PR introduces a prop to allow passing a class to that element, while still allowing for the updated interaction of class/style attributes being passed to the `img` element.