### PR TITLE
Pr/subpixel rendering fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rei/cedar",
-  "version": "13.0.0-next.7",
+  "version": "13.0.0-next.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rei/cedar",
-      "version": "13.0.0-next.7",
+      "version": "13.0.0-next.8",
       "license": "MIT",
       "dependencies": {
         "core-js": "^3.22.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "backstopjs": "^5.3.0",
         "c8": "^7.11.0",
         "chalk": "^4.1.0",
-        "chromedriver": "^105.0.0",
+        "chromedriver": "^104.0.0",
         "concat": "^1.0.3",
         "cross-env": "^7.0.3",
         "cz-conventional-changelog": "^3.3.0",
@@ -3869,9 +3869,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "105.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-105.0.0.tgz",
-      "integrity": "sha512-BX3GOUW5m6eiW9cVVF8hw+EFxvrGqYCxbwOqnpk8PjbNFqL5xjy7yel+e6ilJPjckAYFutMKs8XJvOs/W85vvg==",
+      "version": "104.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-104.0.0.tgz",
+      "integrity": "sha512-zbHZutN2ATo19xA6nXwwLn+KueD/5w8ap5m4b6bCb8MIaRFnyDwMbFoy7oFAjlSMpCFL3KSaZRiWUwjj//N3yQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -18945,9 +18945,9 @@
       "dev": true
     },
     "chromedriver": {
-      "version": "105.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-105.0.0.tgz",
-      "integrity": "sha512-BX3GOUW5m6eiW9cVVF8hw+EFxvrGqYCxbwOqnpk8PjbNFqL5xjy7yel+e6ilJPjckAYFutMKs8XJvOs/W85vvg==",
+      "version": "104.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-104.0.0.tgz",
+      "integrity": "sha512-zbHZutN2ATo19xA6nXwwLn+KueD/5w8ap5m4b6bCb8MIaRFnyDwMbFoy7oFAjlSMpCFL3KSaZRiWUwjj//N3yQ==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "13.0.0-next.7",
+  "version": "13.0.0-next.8",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "backstopjs": "^5.3.0",
     "c8": "^7.11.0",
     "chalk": "^4.1.0",
-    "chromedriver": "^105.0.0",
+    "chromedriver": "^104.0.0",
     "concat": "^1.0.3",
     "cross-env": "^7.0.3",
     "cz-conventional-changelog": "^3.3.0",

--- a/src/components/banner/styles/CdrBanner.module.scss
+++ b/src/components/banner/styles/CdrBanner.module.scss
@@ -15,10 +15,11 @@
     }
   }
   &__main {
-    grid-area: main;
     display: grid;
+    grid-area: main;
     grid-template-columns: auto 1fr auto;
     grid-template-areas: "icon-left message icon-right";
+    min-height: 3.2rem;
   }
   &__icon-left {
     grid-area: icon-left;

--- a/src/components/banner/styles/vars/CdrBanner.vars.scss
+++ b/src/components/banner/styles/vars/CdrBanner.vars.scss
@@ -6,40 +6,35 @@ $left-border: 0.4rem solid;
 }
 @mixin cdr-banner-default-mixin() {
   background-color: $cdr-color-background-message-default-01;
-  border-top: 0.1rem solid;
-  border-right: 0.1rem solid;
-  border-bottom: 0.1rem solid;
-  border-color: $cdr-color-border-message-default-02;
+  outline: thin solid;
+  outline-color: $cdr-color-border-message-default-02;
+  outline-offset: -1px;
 }
 
 @mixin cdr-banner-info-mixin() {
   background-color:  $cdr-color-background-message-info-01;
-  border-top: 0.1rem solid;
-  border-right: 0.1rem solid;
-  border-bottom: 0.1rem solid;
-  border-color: $cdr-color-border-message-info-02;
+  outline: thin solid;
+  outline-color: $cdr-color-border-message-info-02;
+  outline-offset: -1px;
 }
 
 @mixin cdr-banner-success-mixin() {
   background-color:  $cdr-color-background-message-success-01;
-  border-top: 0.1rem solid;
-  border-right: 0.1rem solid;
-  border-bottom: 0.1rem solid;
-  border-color: $cdr-color-border-message-success-02;
+  outline: thin solid;
+  outline-color: $cdr-color-border-message-success-02;
+  outline-offset: -1px;
 }
 
 @mixin cdr-banner-warning-mixin() {
   background-color:  $cdr-color-background-message-warning-01;
-  border-top: 0.1rem solid;
-  border-right: 0.1rem solid;
-  border-bottom: 0.1rem solid;
-  border-color: $cdr-color-border-message-warning-02;
+  outline: thin solid;
+  outline-color: $cdr-color-border-message-warning-02;
+  outline-offset: -1px;
 }
 
 @mixin cdr-banner-error-mixin() {
   background-color:  $cdr-color-background-message-error-01;
-  border-top: 0.1rem solid;
-  border-right: 0.1rem solid;
-  border-bottom: 0.1rem solid;
-  border-color: $cdr-color-border-message-error-02;
+  outline: thin solid;
+  outline-color: $cdr-color-border-message-error-02;
+  outline-offset: -1px;
 }

--- a/src/components/toast/styles/CdrToast.module.scss
+++ b/src/components/toast/styles/CdrToast.module.scss
@@ -28,6 +28,7 @@
     display: grid;
     grid-template-columns: auto 1fr auto;
     grid-template-areas: "icon-left message close-button";
+    min-height: 3.2rem;
   }
 
   &__icon-left {

--- a/src/components/toast/styles/vars/CdrToast.vars.scss
+++ b/src/components/toast/styles/vars/CdrToast.vars.scss
@@ -12,43 +12,35 @@ $timing-function: $cdr-timing-function-ease-out;
 }
 @mixin cdr-toast-default-mixin() {
   background-color: $cdr-color-background-message-default-01;
-  border-top: 0.1rem solid;
-  border-right: 0.1rem solid;
-  border-bottom: 0.1rem solid;
-  border-color: $cdr-color-border-message-default-02;
+  outline: thin solid;
+  outline-color: $cdr-color-border-message-default-02;
+  outline-offset: -1px;
 }
 
 @mixin cdr-toast-info-mixin() {
   background-color:  $cdr-color-background-message-info-01;
-  border-top: 0.1rem solid;
-  border-right: 0.1rem solid;
-  border-bottom: 0.1rem solid;
-  border-color: $cdr-color-border-message-info-02;
+  outline: thin solid;
+  outline-color: $cdr-color-border-message-info-02;
+  outline-offset: -1px;
 }
 
 @mixin cdr-toast-success-mixin() {
   background-color:  $cdr-color-background-message-success-01;
-  border-top: 0.1rem solid;
-  border-right: 0.1rem solid;
-  border-bottom: 0.1rem solid;
-  border-color: $cdr-color-border-message-success-02;
+  outline: thin solid;
+  outline-color: $cdr-color-border-message-success-02;
+  outline-offset: -1px;
 }
 
 @mixin cdr-toast-warning-mixin() {
   background-color:  $cdr-color-background-message-warning-01;
-  border-top: 0.1rem solid;
-  border-right: 0.1rem solid;
-  border-bottom: 0.1rem solid;
-  border-color: $cdr-color-border-message-warning-02;
+  outline: thin solid;
+  outline-color: $cdr-color-border-message-warning-02;
+  outline-offset: -1px;
 }
 
 @mixin cdr-toast-error-mixin() {
   background-color:  $cdr-color-background-message-error-01;
-  border-top: 0.1rem solid;
-  border-right: 0.1rem solid;
-  border-bottom: 0.1rem solid;
-  border-color: $cdr-color-border-message-error-02;
-  svg {
-    fill: $cdr-color-icon-message-error;
-  }
+  outline: thin solid;
+  outline-color: $cdr-color-border-message-error-02;
+  outline-offset: -1px;
 }


### PR DESCRIPTION
At certain zoom levels, there was subtle visual glitch in toast and banner do to subpixel rendering of the component's borders. Changing to outline and enforcing a minimum width (to account for outline having no implicit height) fixes the issue.