### PR TITLE
fix(modal): fix rendering of close button when title is hidden

### DIFF
--- a/src/components/modal/CdrModal.vue
+++ b/src/components/modal/CdrModal.vue
@@ -316,12 +316,14 @@ export default defineComponent({
                   :class="style['cdr-modal__header']"
                   ref="headerEl"
                 >
-                  <slot
-                    name="title"
-                    v-if="showTitle"
-                  >
-                    <h1>{{ label }}</h1>
-                  </slot>
+                  <div :class="style['cdr-modal__title']">
+                    <slot
+                      name="title"
+                      v-if="showTitle"
+                    >
+                      <h1>{{ label }}</h1>
+                    </slot>
+                  </div>
                   <cdr-button
                     :class="style['cdr-modal__close-button']"
                     icon-only

--- a/src/components/modal/__tests__/__snapshots__/CdrModal.spec.js.snap
+++ b/src/components/modal/__tests__/__snapshots__/CdrModal.spec.js.snap
@@ -35,11 +35,15 @@ exports[`CdrModal.vue > default closed > renders correctly 1`] = `
             <div
               class="cdr-modal__header"
             >
-              
-              <h1>
-                Label is the modal title
-              </h1>
-              
+              <div
+                class="cdr-modal__title"
+              >
+                
+                <h1>
+                  Label is the modal title
+                </h1>
+                
+              </div>
               <button
                 aria-label="Close"
                 class="cdr-button cdr-button--primary cdr-button--icon-only-medium cdr-button--icon-only cdr-button--with-background cdr-modal__close-button"
@@ -127,11 +131,15 @@ exports[`CdrModal.vue > default open > renders correctly 1`] = `
             <div
               class="cdr-modal__header"
             >
-              
-              <h1>
-                Label is the modal title
-              </h1>
-              
+              <div
+                class="cdr-modal__title"
+              >
+                
+                <h1>
+                  Label is the modal title
+                </h1>
+                
+              </div>
               <button
                 aria-label="Close"
                 class="cdr-button cdr-button--primary cdr-button--icon-only-medium cdr-button--icon-only cdr-button--with-background cdr-modal__close-button"
@@ -221,11 +229,15 @@ exports[`CdrModal.vue > fullscreen snapshot > renders correctly 1`] = `
             <div
               class="cdr-modal__header"
             >
-              
-              <h1>
-                Label is the modal title
-              </h1>
-              
+              <div
+                class="cdr-modal__title"
+              >
+                
+                <h1>
+                  Label is the modal title
+                </h1>
+                
+              </div>
               <button
                 aria-label="Close"
                 class="cdr-button cdr-button--primary cdr-button--icon-only-medium cdr-button--icon-only cdr-button--with-background cdr-modal__close-button"

--- a/src/components/modal/styles/CdrModal.module.scss
+++ b/src/components/modal/styles/CdrModal.module.scss
@@ -79,13 +79,13 @@ $modal-animation-duration: 150ms;
   &__header {
     display: flex;
     padding-bottom: $cdr-space-one-x;
-    flex: auto;
     justify-content: space-between;
+  }
+  &__title {
+    flex: auto;
     @include cdr-text-heading-serif-600;
   }
   &__close-button {
-    align-self: flex-start;
-    border: 1px solid $cdr-color-icon-default;
     flex: none;
     margin-left: $cdr-space-half-x;
     padding: 7px;


### PR DESCRIPTION
This reverts some of the "flattening" I did in modal, which inadvertently caused a small visual issue when the title was hidden.

Will go out as patch version 13.0.2