### PR TITLE
feat(input): adds support for type of date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rei/cedar",
-  "version": "13.2.2",
+  "version": "13.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rei/cedar",
-      "version": "13.2.2",
+      "version": "13.3.0",
       "license": "MIT",
       "dependencies": {
         "core-js": "^3.22.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "13.2.2",
+  "version": "13.3.0",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/components/input/CdrInput.vue
+++ b/src/components/input/CdrInput.vue
@@ -32,7 +32,7 @@ export default defineComponent({
       default: 'text',
       validator: (value) => propValidator(
         value,
-        ['text', 'email', 'number', 'password', 'search', 'url', 'tel'],
+        ['text', 'email', 'number', 'password', 'search', 'url', 'tel', 'date'],
       ),
     },
     /**

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -203,7 +203,14 @@
         </cdr-link>
       </template>
     </cdr-input>
-
+    <cdr-input
+        label-class="demo-input"
+        v-model="dateModel"
+        label="Date"
+        :background="backgroundColor"
+        type="date"
+        min="2023-01-01"
+      />
     <cdr-input
       label-class="demo-input"
       v-model="helperValidationModel"
@@ -329,6 +336,9 @@
       Form With Buttons Value = {{ formWithButtons }}
     </div>
     <div class="demo-input">
+      Date Input Value = {{ dateModel }}
+    </div>
+    <div class="demo-input">
       Helper/Validation Input Value = {{ helperValidationModel }}
     </div>
     <div class="demo-input">
@@ -361,6 +371,7 @@ export default {
       requiredModel: '',
       optionalModel: '',
       hiddenModel: '',
+      dateModel: '',
       disabledModel: '',
       errorFromProps: 'this error is from props and will appear if no slotted template is provided',
       helperValidationModel: '',
@@ -401,6 +412,7 @@ export default {
       this.multiRowModel = this.masterModel;
       this.sizeModel = this.masterModel;
       this.megaModel = this.masterModel;
+      this.dateModel = this.masterModel;
     },
     setBackground(background) {
       switch (background) {


### PR DESCRIPTION
Unlocks the ability to pass `type="date"` and associated attributes to the underlying input. Unfortunately there's no cross-browser standard for styling the parts of the native date-picker so the experiences is not going to be consistent across browsers. 

That being said, I do think this unlocks enough utility for internal applications to warrant the change.