### PR TITLE
switch component from button to using an input type checkbox

### DIFF
--- a/src/components/switch/CdrSwitch.vue
+++ b/src/components/switch/CdrSwitch.vue
@@ -38,9 +38,6 @@ export default defineComponent({
   setup(props, ctx) {
     const style = useCssModule();
     const uniqueId = props.id ? props.id : uid();
-    const onClick = (modelValue) => {
-      ctx.emit('update:modelValue', !modelValue);
-    };
     const baseClass = 'cdr-switch';
     const sizeClass = computed(() => (props.size
       ? `cdr-switch--${props.size}`
@@ -48,11 +45,20 @@ export default defineComponent({
     const fullWidthClass = computed(() => props.fullWidth
       && buildBooleanClass(baseClass, props.fullWidth, 'full-width'));
 
+    const value = computed({
+      get() {
+        return props.modelValue;
+      },
+      set(newValue) {
+        ctx.emit('update:modelValue', newValue);
+      },
+    });
+
     return {
       style,
       mapClasses,
       uniqueId,
-      onClick,
+      value,
       baseClass,
       sizeClass,
       fullWidthClass,
@@ -76,17 +82,30 @@ export default defineComponent({
     >
       <slot />
     </div>
-    <button
-      @click="onClick(modelValue)"
+    <label
       :class="style['cdr-switch__button']"
       role="switch"
       :aria-checked="modelValue"
       :aria-labelledby="uniqueId"
     >
-      <icon-check-sm :class="style['cdr-switch__button-icon']" />
-      <icon-x-sm :class="style['cdr-switch__button-icon']" />
-      <div :class="style['cdr-switch__handle']" />
-    </button>
+      <input
+        v-show="false"
+        type="checkbox"
+        v-model="value"
+      >
+      <icon-check-sm
+        :class="style['cdr-switch__button-icon']"
+        aria-hidden="true"
+      />
+      <icon-x-sm
+        :class="style['cdr-switch__button-icon']"
+        aria-hidden="true"
+      />
+      <div
+        :class="style['cdr-switch__handle']"
+        aria-hidden="true"
+      />
+    </label>
   </div>
 </template>
 

--- a/src/components/switch/CdrSwitch.vue
+++ b/src/components/switch/CdrSwitch.vue
@@ -85,6 +85,8 @@ export default defineComponent({
     <label
       :class="style['cdr-switch__button']"
       role="switch"
+      tabindex="1"
+      @keyup.space="() => value = !value"
       :aria-checked="modelValue"
       :aria-labelledby="uniqueId"
     >

--- a/src/components/switch/CdrSwitch.vue
+++ b/src/components/switch/CdrSwitch.vue
@@ -85,7 +85,7 @@ export default defineComponent({
     <label
       :class="style['cdr-switch__button']"
       role="switch"
-      tabindex="1"
+      tabindex="0"
       @keyup.space="() => value = !value"
       :aria-checked="modelValue"
       :aria-labelledby="uniqueId"

--- a/src/components/switch/__tests__/Switch.spec.js
+++ b/src/components/switch/__tests__/Switch.spec.js
@@ -3,7 +3,7 @@ import CdrSwitch from '../CdrSwitch.vue';
 
 describe('CdrSwitch', () => {
   let wrapper;
-  let button;
+  let label;
   beforeEach(() => {
     wrapper = mount(CdrSwitch, {
       props: {
@@ -15,7 +15,7 @@ describe('CdrSwitch', () => {
         default: ' <span class="custom-text-style">Pull the lever Kronk!</span>'
       }
     });
-    button = wrapper.find('button');
+    label = wrapper.find('label');
   })
 
   it('matches snapshot', () => {
@@ -23,20 +23,20 @@ describe('CdrSwitch', () => {
   });
 
   it('has a role of "switch"', () => {
-    expect(button.attributes('role')).toBe('switch');
+    expect(label.attributes('role')).toBe('switch');
   });
 
   it('has an "aria-checked" value of "false"', () => {
-    expect(button.attributes('aria-checked')).toBe('false');
+    expect(label.attributes('aria-checked')).toBe('false');
   });
 
   it('the aria-labelledby attribute references the correct id', () => {
-    expect(button.attributes('aria-labelledby')).toBe('id-123');
+    expect(label.attributes('aria-labelledby')).toBe('id-123');
   });
 
   describe('after a click', () => {
     beforeEach(async () => {
-      await button.trigger('click');
+      await label.trigger('click');
     });
 
     it('emits the expected value', () => {
@@ -54,12 +54,12 @@ describe('CdrSwitch', () => {
     });
 
     it('has an "aria-checked" value of "true"', () => {
-      expect(wrapper.find('button').attributes('aria-checked')).toBe('true');
+      expect(wrapper.find('label').attributes('aria-checked')).toBe('true');
     });
 
     describe('after a click', () => {
       beforeEach(async () => {
-        await button.trigger('click')
+        await label.trigger('click')
       });
 
       it('emits the expected value', () => {

--- a/src/components/switch/styles/CdrSwitch.module.scss
+++ b/src/components/switch/styles/CdrSwitch.module.scss
@@ -5,6 +5,9 @@
   align-items: center;
 
   &__button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     margin: 0 $cdr-space-quarter-x;
     padding: 0;
     position: relative;


### PR DESCRIPTION
## Description
rei-cedar team, as a fellow frontend engineer who recently built a vue3 component library I'm always super excited to find another company with engineers who chose to write their own instead of using vutify or primevue, so props for that.

My curiosity lead to finding your switch component, which I was surprised to see just used a button and not a checkbox under the hood. I was under the opinion that a checkbox was the ideal element to store the state for a switch, though in my testing the accessibility and voiceover are virtually identical. I did see that [both are acceptable patterns](https://www.w3.org/WAI/ARIA/apg/patterns/switch/)

> If the switch element is an HTML input[type="checkbox"], it uses the HTML checked attribute instead of the aria-checked property.

Unfortunately using a label/checkbox is not focusable by default, and pressing "space" doesn't toggle the value like it does a button. Obviously those are easy problems to solve and are solved in this PR, but makes the argument for switching to a checkbox a bit harder to justify.

I also wasn't able to figure out how to update snapshots for your snapshot testing with jest, so apologies for that.

Anyways, kudos on the component library 👍

## Checklist:

### Design:
- [ ] Reviewed with designer and meets expectations

### Cross-browser testing:
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari
- [x] iOS
- [ ] Android

### Unit testing:
- [ ] Sufficient unit test coverage (see unit test best practices for ideas)
- [ ] Snapshot updates are explained with comment and reference the relevant source code change

### A11y:
- [x] Meets WCAG AA standards

### Documentation:
- [ ] API docs created/updated
- [ ] Examples created/updated
