### PR TITLE
Restores UMD build for legacy `@rei/ssr` users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rei/cedar",
-  "version": "13.4.1",
+  "version": "13.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rei/cedar",
-      "version": "13.4.1",
+      "version": "13.4.2",
       "license": "MIT",
       "dependencies": {
         "lodash-es": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rei/cedar",
-  "version": "13.4.2-alpha.0",
+  "version": "13.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rei/cedar",
-      "version": "13.4.2-alpha.0",
+      "version": "13.4.2",
       "license": "MIT",
       "dependencies": {
         "lodash-es": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rei/cedar",
-  "version": "13.4.2",
+  "version": "13.4.2-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rei/cedar",
-      "version": "13.4.2",
+      "version": "13.4.2-alpha.0",
       "license": "MIT",
       "dependencies": {
         "lodash-es": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "13.4.2-alpha.0",
+  "version": "13.4.2",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "13.4.1",
+  "version": "13.4.2",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",
@@ -31,7 +31,8 @@
   "scripts": {
     "prepublishOnly": "npm-run-all lint build",
     "dev": "vite",
-    "build": "vite build && npm run build:extractcss && npm run build:icons",
+    "build": "vite build && npm run build:umd && npm run build:extractcss && npm run build:icons",
+    "build:umd": "vite build --config vite.umd.config.mjs",
     "preview": "vite preview",
     "unit": "vitest run",
     "watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "13.4.2",
+  "version": "13.4.2-alpha.0",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/vite.umd.config.mjs
+++ b/vite.umd.config.mjs
@@ -1,0 +1,43 @@
+/// <reference types="vitest" />
+import { fileURLToPath, URL } from "url";
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+import options from "./rollupOptions.mjs";
+
+options.output.preserveModules = false;
+
+const version = process.env.npm_package_version;
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  base: "/rei-cedar-next/",
+  build: {
+    emptyOutDir: false,
+    lib: {
+      entry: "./src/lib.js",
+      formats: ["umd"],
+      name: "cedar",
+    },
+    rollupOptions: options,
+  },
+  server: {
+    port: 3000,
+  },
+  css: {
+    modules: {
+      generateScopedName: (name) => `${name}_${version.replace(/\./g, "-")}`,
+    },
+  },
+  resolve: {
+    alias: {
+      srcdir: fileURLToPath(new URL("./src", import.meta.url)),
+      cssdir: fileURLToPath(new URL("./src/css", import.meta.url)),
+      componentsdir: fileURLToPath(
+        new URL("./src/components", import.meta.url)
+      ),
+      mixinsdir: fileURLToPath(new URL("./src/mixins", import.meta.url)),
+      "~": fileURLToPath(new URL("./node_modules", import.meta.url)),
+    },
+  },
+  plugins: [vue()],
+});


### PR DESCRIPTION
Applications that use server-side rendering on `@rei/ssr@^1.0.0` require CJS/UMD bundles. This PR restores the UMD build so that these users can server-render their bundles. 

This should be considered a "last resort", as consumers should be upgrading their applications to Crampon 4.5 and `@rei/ssr@>=3`, which supports server rendering ESM