### PR TITLE
Adding tree-shaking test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ jsconfig.json
 node_modules
 dist-docs
 dist
+dist-test
 
 # Test results
 .nyc_output

--- a/test/build/build.test.mjs
+++ b/test/build/build.test.mjs
@@ -32,6 +32,12 @@ describe('Library Build ', () => {
     });
 
     expect(appBundles.output[0].code).to.include('CdrButton');
-    expect(appBundles.output[0].code).to.not.include('CdrCard');
+    expect(appBundles.output[0].code).to.include('CdrContainer');
+    expect(appBundles.output[0].code).to.include('CdrCard');
+
+
+    expect(appBundles.output[0].code).to.not.include('CdrGrid');
+    expect(appBundles.output[0].code).to.not.include('CdrList');
+    expect(appBundles.output[0].code).to.not.include('Breadcrumb');
   });
 });

--- a/test/build/build.test.mjs
+++ b/test/build/build.test.mjs
@@ -1,0 +1,37 @@
+import { build } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import { defineConfig } from 'vite';
+
+describe('Library Build ', () => {
+
+  it('should be tree-shakeable', async () => {
+    const libraryConfig = await import('../../vite.config.mjs')
+
+    // Build config overrides.
+    const rawConfig = libraryConfig.config;
+    rawConfig.configFile = false; // needed to pass in this config object instead of reading from fs
+    rawConfig.build.outDir = './dist-test';
+
+    // Build Cedar library
+    await build(defineConfig(rawConfig));
+
+    // Build app using the built Cedar library
+    const appBundles = await build({
+      configFile: false,
+      plugins: [vue()],
+      minify: true,
+      mode: 'production',
+      build: {
+        write: true,
+        rollupOptions: {
+          input: {
+            app: './test/build/harnesses/apps/app1/src/main.mjs'
+          }
+        }
+      }
+    });
+
+    expect(appBundles.output[0].code).to.include('CdrButton');
+    expect(appBundles.output[0].code).to.not.include('CdrCard');
+  });
+});

--- a/test/build/harnesses/apps/app1/src/App.vue
+++ b/test/build/harnesses/apps/app1/src/App.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+    <CdrButton></CdrButton>
+  </div>
+</template>
+
+<script setup>
+
+import { CdrButton } from '../../../../../../dist-test/src/lib.mjs';
+
+</script>
+
+<style>
+#app {
+    font-family: Avenir, Helvetica, Arial, sans-serif;
+}
+</style>

--- a/test/build/harnesses/apps/app1/src/App.vue
+++ b/test/build/harnesses/apps/app1/src/App.vue
@@ -1,12 +1,14 @@
 <template>
   <div>
     <CdrButton></CdrButton>
+    <CdrContainer></CdrContainer>
+    <CdrCard></CdrCard>
   </div>
 </template>
 
 <script setup>
 
-import { CdrButton } from '../../../../../../dist-test/src/lib.mjs';
+import { CdrButton, CdrContainer, CdrCard } from '../../../../../../dist-test/src/lib.mjs';
 
 </script>
 

--- a/test/build/harnesses/apps/app1/src/main.mjs
+++ b/test/build/harnesses/apps/app1/src/main.mjs
@@ -1,0 +1,5 @@
+import { createApp } from 'vue';
+
+import App from './App.vue';
+
+createApp(App).mount('#app');

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -7,8 +7,7 @@ import options from './rollupOptions.mjs';
 
 const version = process.env.npm_package_version;
 
-// https://vitejs.dev/config/
-export default defineConfig({
+export const config = {
   base: '/rei-cedar-next/',
   build: {
     lib: {
@@ -38,4 +37,8 @@ export default defineConfig({
   plugins: [
     vue(),
   ],
-});
+};
+
+
+// https://vitejs.dev/config/
+export default defineConfig(config);

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -13,7 +13,7 @@ export default defineConfig({
     }
   },
   test: {
-    testTimeout: 10000,
+    testTimeout: 15000,
     globals: true,
     exclude: [...configDefaults.exclude, '**/test/e2e', '**/templates/__tests__'],
     environment: 'jsdom',

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -13,6 +13,7 @@ export default defineConfig({
     }
   },
   test: {
+    testTimeout: 10000,
     globals: true,
     exclude: [...configDefaults.exclude, '**/test/e2e', '**/templates/__tests__'],
     environment: 'jsdom',


### PR DESCRIPTION
## Description
In https://github.com/rei/rei-cedar/pull/131, Cedar was updated to be tree-shakeable, this PR follows up on that and adds unit test to ensure tree-shaking is working as expected.

What this test does:

- builds Cedar,
- builds an app that imports CdrButton from dist/lib.mjs ,
- verifies that only CdrButton is in the app bundle.

Implementation notes:

- In the test, I’m re-building Cedar rather than requiring that a build happen prior to running the unit tests. Test can run independently of a build. This results in a longer running test so I had to bump the test timeout.
- I’m building to a separate dist directory, `/dist-test` and import from that in the test app so that we aren’t overwriting Cedar’s default `/dist` directory.
- I’m exporting the raw config object from `vite.config.mjs` because I need to update values prior to the `defineConfig` call, then I call `defineConfig` within the test.

## Checklist:

### Design:
- [ ] Reviewed with designer and meets expectations

### Cross-browser testing:
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] iOS
- [ ] Android

### Unit testing:
- [ ] Sufficient unit test coverage (see unit test best practices for ideas)
- [ ] Snapshot updates are explained with comment and reference the relevant source code change

### A11y:
- [ ] Meets WCAG AA standards

### Documentation:
- [ ] API docs created/updated
- [ ] Examples created/updated
