### PR TITLE
CSS code splitting

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "prepublishOnly": "npm-run-all lint build",
     "dev": "vite",
-    "build": "vite build && npm run build:umd && npm run build:extractcss && npm run build:icons && npm run build:docgen",
+    "build": "vite build && npm run build:umd && npm run build:icons && npm run build:docgen",
     "build:umd": "vite build --config vite.umd.config.mjs",
     "preview": "vite preview",
     "unit": "vitest run",

--- a/vite-plugin-css-name-normalizer.mjs
+++ b/vite-plugin-css-name-normalizer.mjs
@@ -1,0 +1,45 @@
+import path from 'node:path';
+
+/**
+ * Converts a string to kebab case.
+ * @param {*} str
+ */
+function kebabCase(str) {
+  return str
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .replace(/[\s_]+/g, '-')
+    .toLowerCase();
+}
+
+/**
+ * Setting `cssCodeSplit = true` enables chunked
+ * CSS generated from each [cdr-component].module.scss.
+ * By default, Vite will output a name that resembles this:
+ * "CdrChip.module.scss_used_vue_type_style_index_0_src_true_lang.module.css"
+ *
+ * This Vite plugin uses the Rollup hook "generateBundle" to
+ * normalize this output to simply:
+ * cdr-chip.css
+ */
+export default function cssNameNormalizer() {
+  return {
+    name: 'css-name-normalizer',
+    apply(config, { command }) {
+      // apply only on build but not for SSR
+      return command === 'build' && !config.build.ssr;
+    },
+    enforce: 'post',
+    async generateBundle(obj, bundle) {
+      Object.keys(bundle)
+        .filter((key) => {
+          const { ext } = path.parse(key);
+          return ext === '.css';
+        })
+        .forEach((key) => {
+          const entry = bundle[key];
+          const fileName = kebabCase(key.split('.').shift());
+          entry.fileName = `style/${fileName}.css`;
+        });
+    },
+  };
+}

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -4,6 +4,7 @@ import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 // import path from 'path';
 import options from './rollupOptions.mjs';
+import cssNameNormalizer from './vite-plugin-css-name-normalizer.mjs';
 
 const version = process.env.npm_package_version;
 
@@ -11,6 +12,7 @@ const version = process.env.npm_package_version;
 export default defineConfig({
   base: '/rei-cedar-next/',
   build: {
+    cssCodeSplit: true,
     lib: {
       entry: './src/lib.js',
       formats: ['es'],
@@ -37,5 +39,6 @@ export default defineConfig({
   },
   plugins: [
     vue(),
+    cssNameNormalizer(),
   ],
 });


### PR DESCRIPTION
- Enables CSS code splitting for the library which allows chunks of css to be generated.
- Vite plugin to normalize the name of the CSS and to be output to the expected directory (`dist/style`)
- With this change, `cedar-compiled.css` and `cedar-full.css` are no longer generated. Are they necessary?

This should allow Cedar to deprecate the `extract-css.js` script and remove duplicative dependencies. Should also speed up the build.