### PR TITLE
ACS-3918 - v15 modal teleport

### DIFF
--- a/src/components/modal/CdrModal.vue
+++ b/src/components/modal/CdrModal.vue
@@ -144,6 +144,7 @@ const handleKeyDown = ({ key }: { key: string }) => {
     default: break;
   }
 };
+
 const handleFocus = (e: Event) => {
   const { documentElement } = document;
   if (modalEl.value?.contains(e.target as HTMLElement) || !documentElement) return;
@@ -204,7 +205,62 @@ const addHandlers = () => {
   document.addEventListener('keydown', handleKeyDown);
 };
 
+/**
+ * backgroundContentNodes = nodes to target for aria-hidden
+ * backgroundNodesDiscovered = once true, prevents DOM scraping again
+ */
+const backgroundContentNodes: Array<HTMLElement> = [];
+let backgroundNodesDiscovered = false;
+
+/**
+ * Find the nodes that we should aria show/hide
+ * and store them in local state
+ */
+const findBackgroundContentNodes = () => {
+  // initial selector is complex, breaking it down
+  const notSelectors = [
+    'body > *',
+    ':not(script)',
+    ':not(style)',
+    ':not([aria-hidden=true])',
+  ]
+  const contentBodyChildren: NodeListOf<HTMLElement> =
+    document.querySelectorAll(notSelectors.join(''));
+
+  contentBodyChildren.forEach((el) => {
+    // if it's not this modal, or display: none
+    const shouldAddEl = el !== wrapperEl.value
+      && getComputedStyle(el).getPropertyValue('display') !== 'none';
+    if (shouldAddEl) {
+      // save it to the list of nodes to show/hide
+      backgroundContentNodes.push(el);
+    }
+  });
+  backgroundNodesDiscovered = true;
+}
+
+/**
+ * Find the nodes to show/hide on first open,
+ * after that, just add aria-hidden="true"
+ */
+const ariaHideBackgroundContent = () => {
+  if (!backgroundNodesDiscovered) {
+    findBackgroundContentNodes();
+  }
+  backgroundContentNodes.forEach((el) => {
+    el.setAttribute('aria-hidden', 'true');
+  });
+};
+
+// remove aria-hidden from the nodes we tagged
+const ariaShowBackgroundContent = () => {
+  backgroundContentNodes.forEach((el) => {
+    el.removeAttribute('aria-hidden');
+  });
+};
+
 const handleOpened = () => {
+  ariaHideBackgroundContent();
   const { activeElement } = document;
   addNoScroll();
   isOpening.value = true;
@@ -230,6 +286,7 @@ const handleOpened = () => {
 };
 
 const handleClosed = () => {
+  ariaShowBackgroundContent();
   const { documentElement } = document;
   document.removeEventListener('keydown', handleKeyDown);
   document.removeEventListener('focusin', handleFocus, true);
@@ -314,85 +371,87 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div
-    :class="mapClasses(style, baseClass, !opened ? 'cdr-modal--closed' : '')"
-    ref="wrapperEl"
-  >
-    <div :class="[style['cdr-modal__outerWrap'], wrapperClass]">
-      <div
-        aria-hidden="true"
-        @click="onClick"
-        :class="[style['cdr-modal__overlay'], overlayClass]"
-      />
-      <!-- This div (and the one below) is used to avoid a screen reader "keyboard" trap where the
+  <Teleport to="body">
+    <div
+      :class="mapClasses(style, baseClass, !opened ? 'cdr-modal--closed' : '')"
+      ref="wrapperEl"
+    >
+      <div :class="[style['cdr-modal__outerWrap'], wrapperClass]">
+        <div
+          aria-hidden="true"
+          @click="onClick"
+          :class="[style['cdr-modal__overlay'], overlayClass]"
+        />
+        <!-- This div (and the one below) is used to avoid a screen reader "keyboard" trap where the
            content outside the modal is not properly obscured when opened using certain readers.
            Once more browsers catch up to the spec, this hack can probably be removed.
            https://a11ysupport.io/tests/apg__modal-dialog-example -->
-      <div :tabIndex="opened ? '0' : undefined" />
-      <div
-        ref="modalEl"
-        :class="mapClasses(style, 'cdr-modal__contentWrap', 'cdr-modal__dialog')"
-        tabIndex="-1"
-        :role="role"
-        aria-modal="true"
-        :aria-label="label"
-        v-bind="dialogAttrs"
-      >
-        <!-- @slot Use to override the entire CdrModal content container.
+        <div :tabIndex="opened ? '0' : undefined" />
+        <div
+          ref="modalEl"
+          :class="mapClasses(style, 'cdr-modal__contentWrap', 'cdr-modal__dialog')"
+          tabIndex="-1"
+          :role="role"
+          aria-modal="true"
+          :aria-label="label"
+          v-bind="dialogAttrs"
+        >
+          <!-- @slot Use to override the entire CdrModal content container.
           You must provide an explicit way to close the modal
           to meet UX and accessibility standards  -->
-        <slot name="modal">
-          <div
-            :class="[style['cdr-modal__innerWrap'], contentClass]"
-            :style="modalClosed ? { display: 'none' } : undefined"
-          >
-            <section>
-              <div :class="style['cdr-modal__content']">
-                <div
-                  :class="style['cdr-modal__header']"
-                  ref="headerEl"
-                >
-                  <div :class="style['cdr-modal__title']">
-                    <!-- @slot Use to override the default title -->
-                    <slot
-                      name="title"
-                      v-if="showTitle"
-                    >
-                      <h1>{{ label }}</h1>
-                      <!-- @slot CdrModal content -->
-                    </slot>
-                  </div>
-                  <cdr-button
-                    :class="style['cdr-modal__close-button']"
-                    icon-only
-                    :with-background="true"
-                    @click="onClick"
-                    aria-label="Close"
+          <slot name="modal">
+            <div
+              :class="[style['cdr-modal__innerWrap'], contentClass]"
+              :style="modalClosed ? { display: 'none' } : undefined"
+            >
+              <section>
+                <div :class="style['cdr-modal__content']">
+                  <div
+                    :class="style['cdr-modal__header']"
+                    ref="headerEl"
                   >
-                    <template #icon>
-                      <icon-x-lg inherit-color />
-                    </template>
-                  </cdr-button>
-                </div>
+                    <div :class="style['cdr-modal__title']">
+                      <!-- @slot Use to override the default title -->
+                      <slot
+                        name="title"
+                        v-if="showTitle"
+                      >
+                        <h1>{{ label }}</h1>
+                        <!-- @slot CdrModal content -->
+                      </slot>
+                    </div>
+                    <cdr-button
+                      :class="style['cdr-modal__close-button']"
+                      icon-only
+                      :with-background="true"
+                      @click="onClick"
+                      aria-label="Close"
+                    >
+                      <template #icon>
+                        <icon-x-lg inherit-color />
+                      </template>
+                    </cdr-button>
+                  </div>
 
-                <div
-                  :class="style['cdr-modal__text-content']"
-                  :style="textContentStyle"
-                  role="document"
-                  ref="contentEl"
-                  tabindex="0"
-                >
-                  <slot />
+                  <div
+                    :class="style['cdr-modal__text-content']"
+                    :style="textContentStyle"
+                    role="document"
+                    ref="contentEl"
+                    tabindex="0"
+                  >
+                    <slot />
+                  </div>
                 </div>
-              </div>
-            </section>
-          </div>
+              </section>
+            </div>
 
-        </slot>
+          </slot>
+        </div>
+        <div :tabIndex="opened ? '0' : undefined" />
       </div>
-      <div :tabIndex="opened ? '0' : undefined" />
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <style lang="scss" module src="./styles/CdrModal.module.scss">

--- a/src/components/modal/__tests__/__snapshots__/CdrModal.spec.js.snap
+++ b/src/components/modal/__tests__/__snapshots__/CdrModal.spec.js.snap
@@ -1,318 +1,330 @@
 // Vitest Snapshot v1
 
 exports[`CdrModal.vue > default closed > renders correctly 1`] = `
-<div
-  class="cdr-modal cdr-modal--closed"
+<teleport-stub
+  to="body"
 >
   <div
-    class="cdr-modal__outerWrap"
+    class="cdr-modal cdr-modal--closed"
   >
     <div
-      aria-hidden="true"
-      class="cdr-modal__overlay"
-    />
-    <!-- This div (and the one below) is used to avoid a screen reader "keyboard" trap where the
+      class="cdr-modal__outerWrap"
+    >
+      <div
+        aria-hidden="true"
+        class="cdr-modal__overlay"
+      />
+      <!-- This div (and the one below) is used to avoid a screen reader "keyboard" trap where the
            content outside the modal is not properly obscured when opened using certain readers.
            Once more browsers catch up to the spec, this hack can probably be removed.
            https://a11ysupport.io/tests/apg__modal-dialog-example -->
-    <div />
-    <div
-      aria-label="Label is the modal title"
-      aria-modal="true"
-      class="cdr-modal__contentWrap cdr-modal__dialog"
-      role="dialog"
-      tabindex="-1"
-    >
-      <!-- @slot Use to override the entire CdrModal content container.
+      <div />
+      <div
+        aria-label="Label is the modal title"
+        aria-modal="true"
+        class="cdr-modal__contentWrap cdr-modal__dialog"
+        role="dialog"
+        tabindex="-1"
+      >
+        <!-- @slot Use to override the entire CdrModal content container.
           You must provide an explicit way to close the modal
           to meet UX and accessibility standards  -->
-      
-      <div
-        class="cdr-modal__innerWrap"
-        style="display: none;"
-      >
-        <section>
-          <div
-            class="cdr-modal__content"
-          >
+        
+        <div
+          class="cdr-modal__innerWrap"
+          style="display: none;"
+        >
+          <section>
             <div
-              class="cdr-modal__header"
+              class="cdr-modal__content"
             >
               <div
-                class="cdr-modal__title"
+                class="cdr-modal__header"
               >
-                <!-- @slot Use to override the default title -->
+                <div
+                  class="cdr-modal__title"
+                >
+                  <!-- @slot Use to override the default title -->
+                  
+                  <h1>
+                    Label is the modal title
+                  </h1>
+                  <!-- @slot CdrModal content -->
+                  
+                </div>
+                <button
+                  aria-label="Close"
+                  class="cdr-button cdr-button--primary cdr-button--icon-only-medium cdr-button--icon-only cdr-button--with-background cdr-modal__close-button"
+                  type="button"
+                >
+                  <!-- @slot Icon to the left of text content -->
+                  
+                  
+                  <!-- @slot Icon for icon-only button -->
+                  
+                  <svg
+                    aria-hidden="true"
+                    class="cdr-icon cdr-icon--medium cdr-icon--inherit-color"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    
+                    
+                    
+                    <path
+                      d="M13.415 12.006l5.295-5.292a1 1 0 00-1.414-1.415L12 10.591 6.71 5.296A1 1 0 005.295 6.71l5.292 5.295-5.295 5.292a1 1 0 101.414 1.414l5.295-5.292 5.292 5.295a1 1 0 001.414-1.414l-5.292-5.294z"
+                      role="presentation"
+                    />
+                    
+                    <!--v-if-->
+                  </svg>
+                  
+                  <!-- @slot Readable text of the button. Leave empty if icon-only -->
+                  
+                  
+                  <!-- @slot Icon to the right of text content -->
+                  
+                  
+                </button>
+              </div>
+              <div
+                class="cdr-modal__text-content"
+                role="document"
+                style="max-height: -80px; padding-right: 0px;"
+                tabindex="0"
+              >
                 
-                <h1>
-                  Label is the modal title
-                </h1>
-                <!-- @slot CdrModal content -->
+                Sticky content
                 
               </div>
-              <button
-                aria-label="Close"
-                class="cdr-button cdr-button--primary cdr-button--icon-only-medium cdr-button--icon-only cdr-button--with-background cdr-modal__close-button"
-                type="button"
-              >
-                <!-- @slot Icon to the left of text content -->
-                
-                
-                <!-- @slot Icon for icon-only button -->
-                
-                <svg
-                  aria-hidden="true"
-                  class="cdr-icon cdr-icon--medium cdr-icon--inherit-color"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  
-                  
-                  
-                  <path
-                    d="M13.415 12.006l5.295-5.292a1 1 0 00-1.414-1.415L12 10.591 6.71 5.296A1 1 0 005.295 6.71l5.292 5.295-5.295 5.292a1 1 0 101.414 1.414l5.295-5.292 5.292 5.295a1 1 0 001.414-1.414l-5.292-5.294z"
-                    role="presentation"
-                  />
-                  
-                  <!--v-if-->
-                </svg>
-                
-                <!-- @slot Readable text of the button. Leave empty if icon-only -->
-                
-                
-                <!-- @slot Icon to the right of text content -->
-                
-                
-              </button>
             </div>
-            <div
-              class="cdr-modal__text-content"
-              role="document"
-              style="max-height: -80px; padding-right: 0px;"
-              tabindex="0"
-            >
-              
-              Sticky content
-              
-            </div>
-          </div>
-        </section>
+          </section>
+        </div>
+        
       </div>
-      
+      <div />
     </div>
-    <div />
   </div>
-</div>
+</teleport-stub>
 `;
 
 exports[`CdrModal.vue > default open > renders correctly 1`] = `
-<div
-  class="cdr-modal"
+<teleport-stub
+  to="body"
 >
   <div
-    class="cdr-modal__outerWrap"
+    class="cdr-modal"
   >
     <div
-      aria-hidden="true"
-      class="cdr-modal__overlay"
-    />
-    <!-- This div (and the one below) is used to avoid a screen reader "keyboard" trap where the
+      class="cdr-modal__outerWrap"
+    >
+      <div
+        aria-hidden="true"
+        class="cdr-modal__overlay"
+      />
+      <!-- This div (and the one below) is used to avoid a screen reader "keyboard" trap where the
            content outside the modal is not properly obscured when opened using certain readers.
            Once more browsers catch up to the spec, this hack can probably be removed.
            https://a11ysupport.io/tests/apg__modal-dialog-example -->
-    <div
-      tabindex="0"
-    />
-    <div
-      aria-label="Label is the modal title"
-      aria-modal="true"
-      class="cdr-modal__contentWrap cdr-modal__dialog"
-      role="dialog"
-      tabindex="-1"
-    >
-      <!-- @slot Use to override the entire CdrModal content container.
+      <div
+        tabindex="0"
+      />
+      <div
+        aria-label="Label is the modal title"
+        aria-modal="true"
+        class="cdr-modal__contentWrap cdr-modal__dialog"
+        role="dialog"
+        tabindex="-1"
+      >
+        <!-- @slot Use to override the entire CdrModal content container.
           You must provide an explicit way to close the modal
           to meet UX and accessibility standards  -->
-      
-      <div
-        class="cdr-modal__innerWrap"
-      >
-        <section>
-          <div
-            class="cdr-modal__content"
-          >
+        
+        <div
+          class="cdr-modal__innerWrap"
+        >
+          <section>
             <div
-              class="cdr-modal__header"
+              class="cdr-modal__content"
             >
               <div
-                class="cdr-modal__title"
+                class="cdr-modal__header"
               >
-                <!-- @slot Use to override the default title -->
+                <div
+                  class="cdr-modal__title"
+                >
+                  <!-- @slot Use to override the default title -->
+                  
+                  <h1>
+                    Label is the modal title
+                  </h1>
+                  <!-- @slot CdrModal content -->
+                  
+                </div>
+                <button
+                  aria-label="Close"
+                  class="cdr-button cdr-button--primary cdr-button--icon-only-medium cdr-button--icon-only cdr-button--with-background cdr-modal__close-button"
+                  type="button"
+                >
+                  <!-- @slot Icon to the left of text content -->
+                  
+                  
+                  <!-- @slot Icon for icon-only button -->
+                  
+                  <svg
+                    aria-hidden="true"
+                    class="cdr-icon cdr-icon--medium cdr-icon--inherit-color"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    
+                    
+                    
+                    <path
+                      d="M13.415 12.006l5.295-5.292a1 1 0 00-1.414-1.415L12 10.591 6.71 5.296A1 1 0 005.295 6.71l5.292 5.295-5.295 5.292a1 1 0 101.414 1.414l5.295-5.292 5.292 5.295a1 1 0 001.414-1.414l-5.292-5.294z"
+                      role="presentation"
+                    />
+                    
+                    <!--v-if-->
+                  </svg>
+                  
+                  <!-- @slot Readable text of the button. Leave empty if icon-only -->
+                  
+                  
+                  <!-- @slot Icon to the right of text content -->
+                  
+                  
+                </button>
+              </div>
+              <div
+                class="cdr-modal__text-content"
+                role="document"
+                style="max-height: 688px; padding-right: 0px;"
+                tabindex="0"
+              >
                 
-                <h1>
-                  Label is the modal title
-                </h1>
-                <!-- @slot CdrModal content -->
+                Sticky content
                 
               </div>
-              <button
-                aria-label="Close"
-                class="cdr-button cdr-button--primary cdr-button--icon-only-medium cdr-button--icon-only cdr-button--with-background cdr-modal__close-button"
-                type="button"
-              >
-                <!-- @slot Icon to the left of text content -->
-                
-                
-                <!-- @slot Icon for icon-only button -->
-                
-                <svg
-                  aria-hidden="true"
-                  class="cdr-icon cdr-icon--medium cdr-icon--inherit-color"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  
-                  
-                  
-                  <path
-                    d="M13.415 12.006l5.295-5.292a1 1 0 00-1.414-1.415L12 10.591 6.71 5.296A1 1 0 005.295 6.71l5.292 5.295-5.295 5.292a1 1 0 101.414 1.414l5.295-5.292 5.292 5.295a1 1 0 001.414-1.414l-5.292-5.294z"
-                    role="presentation"
-                  />
-                  
-                  <!--v-if-->
-                </svg>
-                
-                <!-- @slot Readable text of the button. Leave empty if icon-only -->
-                
-                
-                <!-- @slot Icon to the right of text content -->
-                
-                
-              </button>
             </div>
-            <div
-              class="cdr-modal__text-content"
-              role="document"
-              style="max-height: 688px; padding-right: 0px;"
-              tabindex="0"
-            >
-              
-              Sticky content
-              
-            </div>
-          </div>
-        </section>
+          </section>
+        </div>
+        
       </div>
-      
+      <div
+        tabindex="0"
+      />
     </div>
-    <div
-      tabindex="0"
-    />
   </div>
-</div>
+</teleport-stub>
 `;
 
 exports[`CdrModal.vue > fullscreen snapshot > renders correctly 1`] = `
-<div
-  class="cdr-modal"
+<teleport-stub
+  to="body"
 >
   <div
-    class="cdr-modal__outerWrap"
+    class="cdr-modal"
   >
     <div
-      aria-hidden="true"
-      class="cdr-modal__overlay"
-    />
-    <!-- This div (and the one below) is used to avoid a screen reader "keyboard" trap where the
+      class="cdr-modal__outerWrap"
+    >
+      <div
+        aria-hidden="true"
+        class="cdr-modal__overlay"
+      />
+      <!-- This div (and the one below) is used to avoid a screen reader "keyboard" trap where the
            content outside the modal is not properly obscured when opened using certain readers.
            Once more browsers catch up to the spec, this hack can probably be removed.
            https://a11ysupport.io/tests/apg__modal-dialog-example -->
-    <div
-      tabindex="0"
-    />
-    <div
-      aria-label="Label is the modal title"
-      aria-modal="true"
-      class="cdr-modal__contentWrap cdr-modal__dialog"
-      role="dialog"
-      tabindex="-1"
-    >
-      <!-- @slot Use to override the entire CdrModal content container.
+      <div
+        tabindex="0"
+      />
+      <div
+        aria-label="Label is the modal title"
+        aria-modal="true"
+        class="cdr-modal__contentWrap cdr-modal__dialog"
+        role="dialog"
+        tabindex="-1"
+      >
+        <!-- @slot Use to override the entire CdrModal content container.
           You must provide an explicit way to close the modal
           to meet UX and accessibility standards  -->
-      
-      <div
-        class="cdr-modal__innerWrap"
-      >
-        <section>
-          <div
-            class="cdr-modal__content"
-          >
+        
+        <div
+          class="cdr-modal__innerWrap"
+        >
+          <section>
             <div
-              class="cdr-modal__header"
+              class="cdr-modal__content"
             >
               <div
-                class="cdr-modal__title"
+                class="cdr-modal__header"
               >
-                <!-- @slot Use to override the default title -->
+                <div
+                  class="cdr-modal__title"
+                >
+                  <!-- @slot Use to override the default title -->
+                  
+                  <h1>
+                    Label is the modal title
+                  </h1>
+                  <!-- @slot CdrModal content -->
+                  
+                </div>
+                <button
+                  aria-label="Close"
+                  class="cdr-button cdr-button--primary cdr-button--icon-only-medium cdr-button--icon-only cdr-button--with-background cdr-modal__close-button"
+                  type="button"
+                >
+                  <!-- @slot Icon to the left of text content -->
+                  
+                  
+                  <!-- @slot Icon for icon-only button -->
+                  
+                  <svg
+                    aria-hidden="true"
+                    class="cdr-icon cdr-icon--medium cdr-icon--inherit-color"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    
+                    
+                    
+                    <path
+                      d="M13.415 12.006l5.295-5.292a1 1 0 00-1.414-1.415L12 10.591 6.71 5.296A1 1 0 005.295 6.71l5.292 5.295-5.295 5.292a1 1 0 101.414 1.414l5.295-5.292 5.292 5.295a1 1 0 001.414-1.414l-5.292-5.294z"
+                      role="presentation"
+                    />
+                    
+                    <!--v-if-->
+                  </svg>
+                  
+                  <!-- @slot Readable text of the button. Leave empty if icon-only -->
+                  
+                  
+                  <!-- @slot Icon to the right of text content -->
+                  
+                  
+                </button>
+              </div>
+              <div
+                class="cdr-modal__text-content"
+                role="document"
+                style="max-height: 688px; padding-right: 0px;"
+                tabindex="0"
+              >
                 
-                <h1>
-                  Label is the modal title
-                </h1>
-                <!-- @slot CdrModal content -->
                 
               </div>
-              <button
-                aria-label="Close"
-                class="cdr-button cdr-button--primary cdr-button--icon-only-medium cdr-button--icon-only cdr-button--with-background cdr-modal__close-button"
-                type="button"
-              >
-                <!-- @slot Icon to the left of text content -->
-                
-                
-                <!-- @slot Icon for icon-only button -->
-                
-                <svg
-                  aria-hidden="true"
-                  class="cdr-icon cdr-icon--medium cdr-icon--inherit-color"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  
-                  
-                  
-                  <path
-                    d="M13.415 12.006l5.295-5.292a1 1 0 00-1.414-1.415L12 10.591 6.71 5.296A1 1 0 005.295 6.71l5.292 5.295-5.295 5.292a1 1 0 101.414 1.414l5.295-5.292 5.292 5.295a1 1 0 001.414-1.414l-5.292-5.294z"
-                    role="presentation"
-                  />
-                  
-                  <!--v-if-->
-                </svg>
-                
-                <!-- @slot Readable text of the button. Leave empty if icon-only -->
-                
-                
-                <!-- @slot Icon to the right of text content -->
-                
-                
-              </button>
             </div>
-            <div
-              class="cdr-modal__text-content"
-              role="document"
-              style="max-height: 688px; padding-right: 0px;"
-              tabindex="0"
-            >
-              
-              
-            </div>
-          </div>
-        </section>
+          </section>
+        </div>
+        
       </div>
-      
+      <div
+        tabindex="0"
+      />
     </div>
-    <div
-      tabindex="0"
-    />
   </div>
-</div>
+</teleport-stub>
 `;


### PR DESCRIPTION
## Description

- Fixes the issue where screen readers can read content outside the modal in Android Talkback (possibly other combos).
- Upon mounting, any modal instances will now be teleported to the root of the document.body element. When the modal is opened, other top-level children of the body element that could contain screen-readable content will be marked `aria-hidden="true"` to prevent them from being read by certain screen readers.

BREAKING CHANGE: This may not be a breaking change for teams, but they will need to test that it works for their specific implementation, and most importantly, their tests.  Most likely issues will occur around UI tests and and unit tests.  Will have full details in release notes, sending separately to Cedar team.

**Note:** Hide whitespace before you review to clean up template and snapshot diffs.

## Checklist:

### Design:
- [x] (NA, no design changes) Reviewed with designer and meets expectations

### Cross-browser testing:
This was covered in internal JIRA ticket, sending link to team separately along with live examples of the issue and fix.
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari
- [x] iOS
- [x] Android

### Unit testing:
- [x] Sufficient unit test coverage (see unit test best practices for ideas)
- [x] Snapshot updates are explained with comment and reference the relevant source code change

### A11y:
- [x] Meets WCAG AA standards

### Documentation:
- [x] (NA) API docs created/updated
- [x] (NA) Examples created/updated
