### PR TITLE
build: removes depth from built asset paths introduced in vite 5  and…

### DIFF
--- a/vite-plugin-css-name-normalizer.ts
+++ b/vite-plugin-css-name-normalizer.ts
@@ -39,7 +39,8 @@ export default async function cssNameNormalizer(): Promise<Plugin> {
         })
         .forEach((key) => {
           const entry = bundle[key];
-          const fileName = kebabCase(key.split('.').shift());
+          const filePath = kebabCase(key.split('.').shift());
+          const fileName = filePath.split('/').pop();
           entry.fileName = `style/${fileName}.css`;
         });
     },


### PR DESCRIPTION
I'm not sure exactly what change in Vite 5 caused this, but the style asset was getting generated with a much deeper path after upgrading.

e.g. `dist/style/src/components/button/styles/cdr-button.css`

This PR adds a little more string manipulation to just return the `cdr-button.css` and preserve our flat static asset structure.