### PR TITLE
Mark `@rei/cdr-tokens` as external

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ src/**/styles/themes/*
 
 src/**/package-lock\.json
 unmigrated/
+
+## Dev output for hosting
+pages

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "15.2.1",
       "license": "MIT",
       "dependencies": {
+        "@rei/cdr-tokens": "^12.3.0",
         "tabbable": "^4.0.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.18.2",
         "@emotion/is-prop-valid": "^1.2.1",
-        "@rei/cdr-tokens": "^12.3.0",
         "@rei/cedar-icons": "^2.6.1",
         "@rollup/plugin-babel": "^6.0.3",
         "@types/tabbable": "^3.1.2",
@@ -3067,7 +3067,6 @@
     "node_modules/@rei/cdr-tokens": {
       "version": "12.3.0",
       "resolved": "git+ssh://git@github.com/rei/rei-cedar-tokens.git#02446ea636a23bd896c7fadcb58e60c80d1ff709",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 20.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rei/cedar",
-  "version": "15.2.0",
+  "version": "15.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rei/cedar",
-      "version": "15.2.0",
+      "version": "15.2.1",
       "license": "MIT",
       "dependencies": {
         "tabbable": "^4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "15.2.0",
       "license": "MIT",
       "dependencies": {
-        "@rei/cdr-tokens": "^12.4.1",
+        "@rei/cdr-tokens": "^12.4.2",
         "tabbable": "^4.0.0"
       },
       "devDependencies": {
@@ -3065,9 +3065,9 @@
       }
     },
     "node_modules/@rei/cdr-tokens": {
-      "version": "12.4.1",
-      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-12.4.1.tgz",
-      "integrity": "sha512-RTi3uaCX/f/LO8Nyo7VcP1IJBQH5vylPjIIDFHNVZzBN8DXy3mCMLi/pIBdPg89OHvWt+TUOaBfDC6zFLl/1oA==",
+      "version": "12.4.2",
+      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-12.4.2.tgz",
+      "integrity": "sha512-QTuq1fu8UOIxtbBjncvC7yr+tJzV23BuIvuTUkgopVuQR067A48f1gMKc1SRX4hljNKzWS5r6sVD/f6Z12gAGw==",
       "engines": {
         "node": ">= 20.0.0",
         "npm": ">= 10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@rei/cedar",
-  "version": "15.2.1",
+  "version": "15.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rei/cedar",
-      "version": "15.2.1",
+      "version": "15.2.0",
       "license": "MIT",
       "dependencies": {
-        "@rei/cdr-tokens": "^12.3.0",
+        "@rei/cdr-tokens": "^12.4.1",
         "tabbable": "^4.0.0"
       },
       "devDependencies": {
@@ -3065,9 +3065,9 @@
       }
     },
     "node_modules/@rei/cdr-tokens": {
-      "version": "12.3.0",
-      "resolved": "git+ssh://git@github.com/rei/rei-cedar-tokens.git#02446ea636a23bd896c7fadcb58e60c80d1ff709",
-      "license": "ISC",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-12.4.1.tgz",
+      "integrity": "sha512-RTi3uaCX/f/LO8Nyo7VcP1IJBQH5vylPjIIDFHNVZzBN8DXy3mCMLi/pIBdPg89OHvWt+TUOaBfDC6zFLl/1oA==",
       "engines": {
         "node": ">= 20.0.0",
         "npm": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     }
   },
   "dependencies": {
-    "@rei/cdr-tokens": "^12.4.1",
+    "@rei/cdr-tokens": "^12.4.2",
     "tabbable": "^4.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "15.2.0",
+  "version": "15.2.1",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",
@@ -13,12 +13,12 @@
   },
   "author": "REI Software Engineering",
   "main": "./dist/cedar.umd.js",
-  "module": "./dist/src/lib.mjs",
+  "module": "./dist/lib.mjs",
   "types": "./dist/lib.d.ts",
   "exports": {
     ".": {
       "types": "./dist/lib.d.ts",
-      "import": "./dist/src/lib.mjs",
+      "import": "./dist/lib.mjs",
       "require": "./dist/cedar.umd.js"
     },
     "./dist/": "./dist/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "15.2.1",
+  "version": "15.2.0",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",
@@ -126,7 +126,7 @@
     }
   },
   "dependencies": {
-    "@rei/cdr-tokens": "^12.3.0",
+    "@rei/cdr-tokens": "^12.4.1",
     "tabbable": "^4.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   "devDependencies": {
     "@babel/preset-env": "^7.18.2",
     "@emotion/is-prop-valid": "^1.2.1",
-    "@rei/cdr-tokens": "^12.3.0",
     "@rei/cedar-icons": "^2.6.1",
     "@rollup/plugin-babel": "^6.0.3",
     "@types/tabbable": "^3.1.2",
@@ -127,6 +126,7 @@
     }
   },
   "dependencies": {
+    "@rei/cdr-tokens": "^12.3.0",
     "tabbable": "^4.0.0"
   },
   "peerDependencies": {

--- a/rollupOptions.mjs
+++ b/rollupOptions.mjs
@@ -3,9 +3,10 @@ import browserTargets from './browserTargets.mjs';
 
 export default {
   // Externalize peerDependencies
-  external: (id) => ['vue', 'core-js', 'tabbable'].some(
-    (dep) => dep === id || id.startsWith(`${dep}/`),
-  ),
+  external: (id) =>
+    ['vue', 'core-js', '@rei/cdr-tokens', 'tabbable'].some(
+      (dep) => dep === id || id.startsWith(`${dep}/`),
+    ),
   output: {
     globals: {
       vue: 'Vue',

--- a/src/components/modal/CdrModal.vue
+++ b/src/components/modal/CdrModal.vue
@@ -15,7 +15,7 @@ import {
   CdrBreakpointSm,
   CdrSpaceOneX,
   CdrSpaceTwoX,
-} from '@rei/cdr-tokens/dist/rei-dot-com/js/cdr-tokens.mjs';
+} from '@rei/cdr-tokens';
 import onTransitionEnd from './onTransitionEnd';
 import CdrButton from '../button/CdrButton.vue';
 import IconXLg from '../icon/comps/x-lg.vue';

--- a/src/components/tabs/CdrTabs.vue
+++ b/src/components/tabs/CdrTabs.vue
@@ -6,7 +6,7 @@ import type { ComponentInternalInstance } from 'vue';
 import { debounce } from '../../utils/debounce'
 import {
   CdrColorBackgroundPrimary, CdrSpaceOneX, CdrSpaceHalfX,
-} from '@rei/cdr-tokens/dist/rei-dot-com/js/cdr-tokens.mjs';
+} from '@rei/cdr-tokens';
 import mapClasses from '../../utils/mapClasses';
 import { modifyClassName } from '../../utils/buildClass';
 import { selectedTabKey } from '../../types/symbols';

--- a/src/mixins/breakpoints.ts
+++ b/src/mixins/breakpoints.ts
@@ -2,7 +2,7 @@ import {
   CdrBreakpointSm,
   CdrBreakpointMd,
   CdrBreakpointLg,
-} from '@rei/cdr-tokens/dist/rei-dot-com/js/cdr-tokens.mjs';
+} from '@rei/cdr-tokens';
 
 export default function getCurrentBreakpoint() {
   const screenWidth = (window && window.innerWidth) || 0;


### PR DESCRIPTION
### Problem

I see an SSR runtime exception from Nitro (Nuxt) derived from dead references in `@rei/cedar`'s distributed modules. When Nuxt builds the application (`nuxt build`), it outputs optimized server assets to `.output/server,` where you'd run a productionized Nuxt app from. 

The Nuxt build heuristics exclude nested `node_modules` directories, instead hoisting them to the top-level `.output/server/node_modules`. However, some `@rei/cedar` modules are dependent on those modules existing in a relative location:

```typescript
// .output/server/node_modules/@rei/cedar/dist/src/components/image/CdrImg.vue2.mjs
import { CdrRadiusSoft as f, CdrRadiusSofter as C, CdrRadiusRound as y } from "../../../node_modules/@rei/cdr-tokens/dist/rei-dot-com/js/cdr-tokens.mjs";
```

This causes the following Nuxt/SSR runtime exception:

```
[Vue Router warn]: uncaught error during route navigation:
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/kmedley/code/alpine-composer/.output/server/node_modules/@rei/cedar/dist/node_modules/@rei/cdr-tokens/dist/rei-dot-com/js/cdr-tokens.mjs' imported from /Users/kmedley/code/alpine-composer/.output/server/node_modules/@rei/cedar/dist/src/components/modal/CdrModal.vue2.mjs
    at finalizeResolution (node:internal/modules/esm/resolve:265:11)
    at moduleResolve (node:internal/modules/esm/resolve:933:10)
    at defaultResolve (node:internal/modules/esm/resolve:1157:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:390:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:359:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:234:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:87:39)
    at link (node:internal/modules/esm/module_job:86:36) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///Users/kmedley/code/alpine-composer/.output/server/node_modules/@rei/cedar/dist/node_modules/@rei/cdr-tokens/dist/rei-dot-com/js/cdr-tokens.mjs'
}
```
In the context of the Alpine ecosystem, this hasn't been a problem because our processes use a customized SSR setup that copies `node_modules` into the Crampon SSR sidecar (docker container). 

### Solution

This PR marks `@rei/cdr-tokens` as external, so the build system doesn't bundle them into the `@rei/cedar` distributed modules. Instead, Cedar modules will directly reference `@rei/cdr-tokens` from `node_modules` at run-time, which should be the expected behavior.

### Side-effects

With `@rei/cdr-tokens` externalized, we need to adjust module entry points for `@rei/cedar`, as Vite no longer outputs `.dist/src`. Those entry points will live in `.dist/`, thus, we update references in `package.json`. Additionally, module references to `@rei/cdr-tokens` are updated to match.
