### PR TITLE
adding padding top/bottom to the --message

### DIFF
--- a/src/components/banner/styles/CdrBanner.module.scss
+++ b/src/components/banner/styles/CdrBanner.module.scss
@@ -44,7 +44,7 @@
   &__message {
     display: inherit;
     grid-area: message;
-    padding: 0 $cdr-space-half-x;
+    padding: $cdr-space-half-x;
     align-items: center;
   }
 


### PR DESCRIPTION
## Description
message text that goes to 2 or three lines is not expected but when it does we would expect that the container surrounding the message retains it padding 
