### PR TITLE
modal height fix

### DIFF
--- a/src/components/modal/styles/CdrModal.module.scss
+++ b/src/components/modal/styles/CdrModal.module.scss
@@ -10,7 +10,7 @@ $modal-animation-duration: 150ms;
   }
 
   inset: 0;
-  height: 100%;
+  height: 100vh;
   overflow-y: scroll;
   position: fixed;
   visibility: visible;


### PR DESCRIPTION
## Description

Updates the modal container's height. This affected Chrome 120, but could also be in a number of other browsers. Apparently, using `position: fixed` the height could be the entire page height in older browsers (or some current ones).

Modal is suppose to be full width and height of viewport, not page, so this seems like a safe fix.