### PR TITLE
modal-patch-mobile

### DIFF
--- a/src/components/modal/examples/Modal.vue
+++ b/src/components/modal/examples/Modal.vue
@@ -76,7 +76,6 @@
     <br />
     <long-modal />
     <div class="spacer" />
-    <div class="sticky">Something sticky</div>
   </div>
 </template>
 
@@ -118,13 +117,5 @@ export default {
 
 .spacer {
   height: 100vh;
-}
-
-.sticky {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  background-color: red;
 }
 </style>

--- a/src/components/modal/examples/Modal.vue
+++ b/src/components/modal/examples/Modal.vue
@@ -75,6 +75,7 @@
     <async-modal />
     <br />
     <long-modal />
+    <div class="spacer" />
   </div>
 </template>
 
@@ -112,5 +113,9 @@ export default {
   .modal-example {
     min-height: 80vh; /* fixes a safari display bug */
   }
+}
+
+.spacer {
+  height: 100vh;
 }
 </style>

--- a/src/components/modal/examples/Modal.vue
+++ b/src/components/modal/examples/Modal.vue
@@ -76,6 +76,7 @@
     <br />
     <long-modal />
     <div class="spacer" />
+    <div class="sticky">Something sticky</div>
   </div>
 </template>
 
@@ -117,5 +118,13 @@ export default {
 
 .spacer {
   height: 100vh;
+}
+
+.sticky {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background-color: red;
 }
 </style>

--- a/src/components/modal/styles/CdrModal.module.scss
+++ b/src/components/modal/styles/CdrModal.module.scss
@@ -151,7 +151,4 @@ $modal-animation-duration: 150ms;
   overflow: hidden !important;
   position: fixed !important;
   width: 100%;
-  height: 100%;
-  top: 0;
-  left: 0;
 }

--- a/src/components/modal/styles/CdrModal.module.scss
+++ b/src/components/modal/styles/CdrModal.module.scss
@@ -10,7 +10,7 @@ $modal-animation-duration: 150ms;
   }
 
   inset: 0;
-  height: 100vh;
+  height: 100%;
   overflow-y: scroll;
   position: fixed;
   visibility: visible;
@@ -151,4 +151,7 @@ $modal-animation-duration: 150ms;
   overflow: hidden !important;
   position: fixed !important;
   width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
 }

--- a/src/dev/SinkWrapper.vue
+++ b/src/dev/SinkWrapper.vue
@@ -67,6 +67,7 @@ export default {
     align-items: center;
     gap: 8px;
     margin-bottom: 8px;
+    container-type: inline-size;
   }
 
   &__container {

--- a/src/styles/cdr-reset.scss
+++ b/src/styles/cdr-reset.scss
@@ -45,8 +45,6 @@ body {
   /* cdr-color-background-primary */
 
   background-color: #ffffff;
-  container-name: cdr-body;
-  container-type: inline-size;
 }
 
 h1,


### PR DESCRIPTION
## Description

The modal positioning was broken on some older versions of Chrome, due to adding the following to body via the cdr-reset file:

```
  container-name: cdr-body;
  container-type: inline-size;
```

This changed was implemented to make it easier for container queries to "just work". However, having a container CSS property applied to the body means that any inner content with a position fixed can be affected in some older browsers—the content would not longer be sticky...it would just stick to the top of "body". For this reason, I have removed it from our reset file. In the future, we may want to add a similar set of styles to CdrContainer. The change for CdrContainer is not added here for the following reasons:
- this is meant as more of a quick fix
- the styles for CdrContainer come from cdr-tokens
- because of the position fixed issue, it may not be best to release the container change within a major version change
- it's not crucial