### PR TITLE
remove container type

### DIFF
--- a/src/components/layout/CdrLayout.vue
+++ b/src/components/layout/CdrLayout.vue
@@ -21,7 +21,6 @@ const props = withDefaults(defineProps<Layout>(), {
   queryType: 'container',
   flow: undefined,
   flowValue: 'auto',
-  containerName: undefined,
 });
 
 const style = useCssModule();
@@ -30,10 +29,6 @@ const rootProps = computed(() => {
   const baseClass = 'cdr-layout';
   const classes = [baseClass];
   const inlineStyles: NameValuePair = {};
-
-  if (props.containerName) {
-    inlineStyles['container-name'] = props.containerName;
-  }
 
   // Add gap for entire grid
   if (props.gap !== 'zero') {

--- a/src/components/layout/styles/vars/CdrLayout.vars.scss
+++ b/src/components/layout/styles/vars/CdrLayout.vars.scss
@@ -6,7 +6,6 @@ $flows: row, column;
 
 @mixin cdr-layout-base-mixin() {
   display: grid;
-  container-type: inline-size;
 }
 
 // Adds in media and container queries for layouts that change at various breakpoints

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -224,10 +224,6 @@ export interface Layout extends NameValuePair {
    * The component or HTML tag to render at the root level. Note: The component "CdrSurface" has special treatment and may be used in quotes.
    */
   as?: Component | string;
-  /**
-   * The container query name that will be applied, if needed
-   */
-  containerName?: string;
 }
 
 /**


### PR DESCRIPTION
Removes `container-type` and `container-name` from layout and media object components. This caused some width issues and not worth the trade-offs.

Demo: https://rei.github.io/rei-cedar/