### PR TITLE
chore: expose shared injection keys via public entry point

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rei/cedar",
-  "version": "15.6.1-beta.0",
+  "version": "15.6.1-export-symbols",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rei/cedar",
-      "version": "15.6.1-beta.0",
+      "version": "15.6.1-export-symbols",
       "license": "MIT",
       "dependencies": {
         "@rei/cdr-tokens": "^12.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rei/cedar",
-  "version": "15.6.1-export-symbols",
+  "version": "15.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rei/cedar",
-      "version": "15.6.1-export-symbols",
+      "version": "15.6.1-beta.1",
       "license": "MIT",
       "dependencies": {
         "@rei/cdr-tokens": "^12.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "15.6.1-beta.0",
+  "version": "15.6.1-export-symbols",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "15.6.1-export-symbols",
+  "version": "15.6.1-beta.1",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -59,6 +59,7 @@ export * from './components/text/presets/textPresets';
 /** Type exports */
 export * from './types/interfaces';
 export * from './types/other';
+export * from './types/symbols';
 
 /** Compile into dist/style folder */
 import './styles/cdr-reset.scss';


### PR DESCRIPTION
This change exports shared `InjectionKey` symbols such as `CdrFilmstripEventKey` from the main `lib.ts` entry point. This allows consumers like `@rei/dxp-library` and Alpine Composer to import these symbols directly from `@rei/cedar`, avoiding deep imports into `dist/types/symbols.mjs`.

- Prevents inconsistent symbol instances across packages
- Eliminates TypeScript declaration errors
- Resolves Vue warnings related to missing injectables

Fixes this:

![Screenshot 2025-04-30 at 8 06 15 AM](https://github.com/user-attachments/assets/b705760c-9bda-405f-9c36-f90a4d15a7f7)
