### PR TITLE
Pull in cdr-tokens v13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "15.6.1-beta.5",
       "license": "MIT",
       "dependencies": {
-        "@rei/cdr-tokens": "^12.7.1",
+        "@rei/cdr-tokens": "^13.0.0",
         "@vueuse/core": "^12.7.0",
         "radix-vue": "^1.9.17",
         "tabbable": "^4.0.0"
@@ -3164,9 +3164,9 @@
       }
     },
     "node_modules/@rei/cdr-tokens": {
-      "version": "12.7.1",
-      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-12.7.1.tgz",
-      "integrity": "sha512-4m3XtGCAmeoYtbd0JGedEPh1OJqsCJ5P2OA2XFDhR/YS6jA26q6fcJiNjwHXczuxe5OlRqg6ppNuqCSM0z5feQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-13.0.0.tgz",
+      "integrity": "sha512-i7rfG1LRv7yQPZoemUTKpsqFsrUMN3T9YMdaw/VK1nBYEy3ZOVVB9hPCaTdExzSLHg3IWoQQdoqPt9jQUvcBBA==",
       "license": "ISC",
       "engines": {
         "node": ">= 20.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rei/cedar",
-  "version": "15.6.1-beta.5",
+  "version": "16.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rei/cedar",
-      "version": "15.6.1-beta.5",
+      "version": "16.0.0",
       "license": "MIT",
       "dependencies": {
         "@rei/cdr-tokens": "^13.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "postcss-calc": "^8.0.0",
         "postcss-pxtorem": "^6.0.0",
         "postcss-scss": "^4.0.9",
-        "sass": "^1.71.1",
+        "sass": "^1.9.0",
         "sinon": "^11.1.0",
         "stylelint": "^16.10.0",
         "stylelint-config-recommended-scss": "^14.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "15.6.1-beta.5",
       "license": "MIT",
       "dependencies": {
-        "@rei/cdr-tokens": "^12.7.1",
+        "@rei/cdr-tokens": "^13.0.0",
         "@vueuse/core": "^12.7.0",
         "radix-vue": "^1.9.17",
         "tabbable": "^4.0.0"
@@ -54,7 +54,7 @@
         "postcss-calc": "^8.0.0",
         "postcss-pxtorem": "^6.0.0",
         "postcss-scss": "^4.0.9",
-        "sass": "^1.32.11",
+        "sass": "^1.71.1",
         "sinon": "^11.1.0",
         "stylelint": "^16.10.0",
         "stylelint-config-recommended-scss": "^14.1.0",
@@ -3164,9 +3164,9 @@
       }
     },
     "node_modules/@rei/cdr-tokens": {
-      "version": "12.7.1",
-      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-12.7.1.tgz",
-      "integrity": "sha512-4m3XtGCAmeoYtbd0JGedEPh1OJqsCJ5P2OA2XFDhR/YS6jA26q6fcJiNjwHXczuxe5OlRqg6ppNuqCSM0z5feQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-13.0.0.tgz",
+      "integrity": "sha512-i7rfG1LRv7yQPZoemUTKpsqFsrUMN3T9YMdaw/VK1nBYEy3ZOVVB9hPCaTdExzSLHg3IWoQQdoqPt9jQUvcBBA==",
       "license": "ISC",
       "engines": {
         "node": ">= 20.0.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "postcss-calc": "^8.0.0",
     "postcss-pxtorem": "^6.0.0",
     "postcss-scss": "^4.0.9",
-    "sass": "^1.71.1",
+    "sass": "^1.9.0",
     "sinon": "^11.1.0",
     "stylelint": "^16.10.0",
     "stylelint-config-recommended-scss": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "pages": "vite build --config vite.pages.config.mts",
     "preview": "vite preview --config vite.pages.config.mts",
     "unit": "vitest run",
+    "unit:update": "vitest --update",
     "watch": "vitest",
     "coverage": "vitest run --coverage",
     "test:playwright": "playwright test",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     }
   },
   "dependencies": {
-    "@rei/cdr-tokens": "^12.7.1",
+    "@rei/cdr-tokens": "^13.0.0",
     "@vueuse/core": "^12.7.0",
     "radix-vue": "^1.9.17",
     "tabbable": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "postcss-calc": "^8.0.0",
     "postcss-pxtorem": "^6.0.0",
     "postcss-scss": "^4.0.9",
-    "sass": "^1.32.11",
+    "sass": "^1.71.1",
     "sinon": "^11.1.0",
     "stylelint": "^16.10.0",
     "stylelint-config-recommended-scss": "^14.1.0",
@@ -131,7 +131,7 @@
     }
   },
   "dependencies": {
-    "@rei/cdr-tokens": "^12.7.1",
+    "@rei/cdr-tokens": "^13.0.0",
     "@vueuse/core": "^12.7.0",
     "radix-vue": "^1.9.17",
     "tabbable": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "15.6.1-beta.5",
+  "version": "16.0.0",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "16.0.0",
+  "version": "15.6.1-beta.4",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/components/accordion/styles/CdrAccordion.module.scss
+++ b/src/components/accordion/styles/CdrAccordion.module.scss
@@ -1,7 +1,7 @@
 @use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 
-@import '../../icon/styles/CdrIcon.module';
-@import './CdrAccordionGroup.module';
+@use '../../icon/styles/CdrIcon.module';
+@use './CdrAccordionGroup.module';
 
 .cdr-accordion {
   //ITEM_DOC: Border color of cdr-accordion

--- a/src/components/breadcrumb/styles/CdrBreadcrumb.module.scss
+++ b/src/components/breadcrumb/styles/CdrBreadcrumb.module.scss
@@ -77,7 +77,7 @@
     @include vars.cdr-breadcrumb-xs-text-mixin;
   }
 
-  @include tokens.cdr-md-mq {
+  @include tokens.cdr-md-mq-up {
     &__link,
     &__delimiter,
     &__ellipses {

--- a/src/components/checkbox/styles/CdrCheckbox.module.scss
+++ b/src/components/checkbox/styles/CdrCheckbox.module.scss
@@ -1,7 +1,7 @@
 @use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 @use './vars/CdrCheckbox.vars' as vars;
 
-@import '../../labelWrapper/styles/CdrLabelWrapper.module';
+@use '../../labelWrapper/styles/CdrLabelWrapper.module';
 
 .cdr-checkbox {
   &__svg-box {

--- a/src/components/container/examples/Container.vue
+++ b/src/components/container/examples/Container.vue
@@ -42,13 +42,13 @@ export default {
 </script>
 
 <style lang="scss">
-@import "node_modules/@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens.scss";
+@use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 
 .tokens-container {
-  @include cdr-container;
+  @include tokens.cdr-container;
 }
 
 .tokens-container-fluid {
-  @include cdr-container-fluid;
+  @include tokens.cdr-container-fluid;
 }
 </style>

--- a/src/components/filmstrip/examples/Lifestyle/Example.vue
+++ b/src/components/filmstrip/examples/Lifestyle/Example.vue
@@ -11,10 +11,9 @@
 
 <script setup lang="ts">
 import CdrFilmstrip from '../../CdrFilmstrip.vue';
-import type { Lifestyle } from './index';
 import lifestyleModel from './mock.json';
 
-const lifestyleModelData = lifestyleModel as Lifestyle;
+const lifestyleModelData = lifestyleModel as Record<string, unknown>;
 import { onFrameClick, onArrowClick, onResize } from './handlers';
 import LifestyleAdapter from './adapter';
 </script>

--- a/src/components/filmstrip/examples/ProductRecommendation/Example.vue
+++ b/src/components/filmstrip/examples/ProductRecommendation/Example.vue
@@ -12,10 +12,9 @@
 
 <script setup lang="ts">
 import CdrFilmstrip from '../../CdrFilmstrip.vue';
-import type { ProductRecommendation } from './index';
 import ProductRecommendationModel from './mock.json';
 
-const ProductRecommendationModelData = ProductRecommendationModel as ProductRecommendation;
+const ProductRecommendationModelData = ProductRecommendationModel as Record<string, unknown>;
 import { onFrameClick, onArrowClick, onScrollNavigate } from './handlers';
 import ProductRecommendationAdapter from './adapter';
 </script>

--- a/src/components/formGroup/styles/CdrFormGroup.module.scss
+++ b/src/components/formGroup/styles/CdrFormGroup.module.scss
@@ -1,7 +1,7 @@
 @use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 @use './vars/CdrFormGroup.vars' as vars;
 
-@import '../../formError/styles/CdrFormError.module';
+@use '../../formError/styles/CdrFormError.module';
 
 .cdr-form-group {
   @include vars.cdr-form-group-base-mixin;

--- a/src/components/grid/examples/Grid.vue
+++ b/src/components/grid/examples/Grid.vue
@@ -57,12 +57,12 @@ export default {
 </script>
 
 <style lang="scss">
-@import "node_modules/@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens.scss";
+@use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 .custom-grid {
   // 3 column at md or lg
   grid-template-columns: 1fr 1fr 1fr;
 
-  @include cdr-sm-mq-down {
+  @include tokens.cdr-sm-mq-down {
     // 1 column at xs or sm
     grid-template-columns: 1fr;
   }
@@ -71,6 +71,6 @@ export default {
 .grid-item {
   border: 1px solid black;
   text-align: center;
-  padding: $cdr-space-one-x;
+  padding: tokens.$cdr-space-one-x;
 }
 </style>

--- a/src/components/input/styles/CdrInput.module.scss
+++ b/src/components/input/styles/CdrInput.module.scss
@@ -1,8 +1,8 @@
 @use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 @use './vars/CdrInput.vars' as vars;
 
-@import '../../labelStandalone/styles/CdrLabelStandalone.module';
-@import '../../formError/styles/CdrFormError.module';
+@use '../../labelStandalone/styles/CdrLabelStandalone.module';
+@use '../../formError/styles/CdrFormError.module';
 
 /* ==========================================================================
   # INPUT LABEL

--- a/src/components/landingLead/styles/CdrHeadingSubheadingBlock.module.scss
+++ b/src/components/landingLead/styles/CdrHeadingSubheadingBlock.module.scss
@@ -1,7 +1,7 @@
 @use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 
-@import '../../text/presets/styles/CdrHeadingDisplay.module';
-@import '../../text/presets/styles/CdrSubheadingSans.module';
+@use '../../text/presets/styles/CdrHeadingDisplay.module';
+@use '../../text/presets/styles/CdrSubheadingSans.module';
 
 .cdr-heading-subheading-block {
   &__heading {

--- a/src/components/landingLead/styles/CdrLandingLead.module.scss
+++ b/src/components/landingLead/styles/CdrLandingLead.module.scss
@@ -1,7 +1,7 @@
 @use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 
-@import '../../image/styles/CdrImg.module';
-@import './CdrHeadingSubheadingBlock.module';
+@use '../../image/styles/CdrImg.module';
+@use './CdrHeadingSubheadingBlock.module';
 
 .cdr-landing-lead {
   //ITEM_DOC: Color of the landing-leads surface layer. Passes to underlying split-surface component

--- a/src/components/layout/examples/Layout.vue
+++ b/src/components/layout/examples/Layout.vue
@@ -156,15 +156,15 @@ const layouts: LayoutExample[] = [
 </template>
 
 <style lang="scss" scoped>
-@import '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens.scss';
+@use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 
 .example {
   &__hr {
-    margin: $cdr-space-two-x 0;
+    margin: tokens.$cdr-space-two-x 0;
   }
 
   &__surface {
-    margin-bottom: $cdr-space-two-x;
+    margin-bottom: tokens.$cdr-space-two-x;
   }
 
   &__container {
@@ -172,21 +172,21 @@ const layouts: LayoutExample[] = [
   }
 
   &__layout-cell {
-    padding: $cdr-space-half-x;
+    padding: tokens.$cdr-space-half-x;
   }
 
   &__cell {
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: $cdr-space-half-x;
+    padding: tokens.$cdr-space-half-x;
   }
 
   &__layout {
     &--tall {
       height: 200px;
 
-      @include cdr-sm-mq-down {
+      @include tokens.cdr-sm-mq-down {
         height: auto;
       }
     }

--- a/src/components/mediaObject/examples/MediaObject.vue
+++ b/src/components/mediaObject/examples/MediaObject.vue
@@ -327,11 +327,11 @@ const columnExamples = [
 </template>
 
 <style lang="scss" scoped>
-@import '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens.scss';
+@use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 
 .example {
   &__hr {
-    margin: $cdr-space-two-x 0;
+    margin: tokens.$cdr-space-two-x 0;
   }
 
   &__container {
@@ -340,7 +340,7 @@ const columnExamples = [
 
   &__content {
     &--color-inverse {
-      color: $cdr-color-text-inverse;
+      color: tokens.$cdr-color-text-inverse;
     }
 
     &--narrow {

--- a/src/components/mediaObject/styles/vars/CdrMediaObject.vars.scss
+++ b/src/components/mediaObject/styles/vars/CdrMediaObject.vars.scss
@@ -42,7 +42,9 @@ $media-object-component: 'media-object';
 
 // Allows for switching positions of media and content at breakpoints
 @mixin cdr-media-object-media-position-mixin($component) {
-  grid-template-areas: var(--cdr-#{$component}-media-position);
+  & {
+    grid-template-areas: var(--cdr-#{$component}-media-position);
+  }
   @include query.cdr-mq-mixin($component, 'media-position');
 }
 
@@ -66,9 +68,12 @@ $media-object-component: 'media-object';
 
 // Allow for content to overlay media
 @mixin cdr-media-object-overlay-mixin($component) {
+  & {
+    grid-template-areas: 'media';
+    position: relative;
+  }
+  
   @include cdr-media-object-cover-mixin($component);
-  grid-template-areas: 'media';
-  position: relative;
 
   @include cdr-media-object-content-mixin {
     position: absolute;

--- a/src/components/modal/examples/components/FancyModal.vue
+++ b/src/components/modal/examples/components/FancyModal.vue
@@ -87,7 +87,7 @@ export default {
 };
 </script>
 <style lang="scss">
-@import "node_modules/@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens.scss";
+@use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 .membership-acquisition-imodal {
   // class to override cedar default class to allow background content more visible to user
   &--overlay-lighter {
@@ -95,24 +95,25 @@ export default {
     background-color: rgba(26, 26, 26, 0.6);
   }
   &__wrapper {
-    padding: $cdr-space-one-x;
-    .close-button-wrapper {
+    & {
+      padding: tokens.$cdr-space-one-x;
+    }
+    & .close-button-wrapper {
       position: absolute;
       right: 0;
       z-index: 1;
     }
-    .modal-close-button {
-      fill: $cdr-color-background-label-secondary-active;
-      @include cdr-sm-mq-down {
-        padding-top: $cdr-space-one-x;
+    & .modal-close-button {
+      fill: tokens.$cdr-color-background-label-secondary-active;
+      @include tokens.cdr-sm-mq-down {
+        padding-top: tokens.$cdr-space-one-x;
       }
     }
-    padding: $cdr-space-one-x;
 
     // Target modal container and avoid full screen behaviour on smaller resolutions.
     div[role="dialog"] {
-      @include cdr-sm-mq-down {
-        border-radius: $cdr-radius-softer;
+      @include tokens.cdr-sm-mq-down {
+        border-radius: tokens.$cdr-radius-softer;
         max-width: 315px;
         min-height: auto;
         position: relative;
@@ -122,7 +123,7 @@ export default {
     .content-wrapper {
       display: flex;
       flex-direction: column;
-      @include cdr-sm-mq-up {
+      @include tokens.cdr-sm-mq-up {
         flex-direction: row;
       }
       .image {
@@ -130,12 +131,12 @@ export default {
         background-size: 100% auto;
         background-position: 0% 55%;
         background-repeat: no-repeat;
-        border-radius: $cdr-radius-softer $cdr-radius-softer 0 0;
+        border-radius: tokens.$cdr-radius-softer tokens.$cdr-radius-softer 0 0;
         height: 180px;
-        @include cdr-sm-mq-up {
+        @include tokens.cdr-sm-mq-up {
           flex: 0 50%;
           height: 370px;
-          border-radius: $cdr-radius-softer 0 0 $cdr-radius-softer;
+          border-radius: tokens.$cdr-radius-softer 0 0 tokens.$cdr-radius-softer;
         }
       }
       .eyebrow {
@@ -144,36 +145,36 @@ export default {
         background: url("https://www.rei.com/assets/membership/benefits/modal/co-op-membership-logo/live.svg");
         background-repeat: no-repeat;
         background-size: 250px 8px;
-        margin: $cdr-space-one-and-a-half-x;
+        margin: tokens.$cdr-space-one-and-a-half-x;
         display: block;
         text-align: center;
-        @include cdr-sm-mq-up {
-          margin-top: $cdr-space-two-x;
+        @include tokens.cdr-sm-mq-up {
+          margin-top: tokens.$cdr-space-two-x;
         }
       }
       .content {
         padding: 8px;
-        @include cdr-sm-mq-up {
+        @include tokens.cdr-sm-mq-up {
           flex: 0 50%;
         }
       }
       .content.green {
-        background-color: $cdr-color-background-brand-spruce;
-        color: $cdr-color-background-label-secondary-active;
-        padding: $cdr-space-one-x;
-        border-radius: 0 0 $cdr-radius-softer $cdr-radius-softer;
+        background-color: tokens.$cdr-color-background-brand-spruce;
+        color: tokens.$cdr-color-background-label-secondary-active;
+        padding: tokens.$cdr-space-one-x;
+        border-radius: 0 0 tokens.$cdr-radius-softer tokens.$cdr-radius-softer;
         button {
           text-align: center;
         }
-        @include cdr-sm-mq-up {
-          border-radius: 0 $cdr-radius-softer $cdr-radius-softer 0;
-          padding: $cdr-space-two-x $cdr-space-one-and-a-half-x;
+        @include tokens.cdr-sm-mq-up {
+          border-radius: 0 tokens.$cdr-radius-softer tokens.$cdr-radius-softer 0;
+          padding: tokens.$cdr-space-two-x tokens.$cdr-space-one-and-a-half-x;
           position: relative;
         }
         .subheading {
-          @include cdr-text-body-300;
-          margin-top: $cdr-space-one-x;
-          margin-bottom: $cdr-space-one-x;
+          @include tokens.cdr-text-body-300;
+          margin-top: tokens.$cdr-space-one-x;
+          margin-bottom: tokens.$cdr-space-one-x;
         }
       }
       .nomargin {
@@ -183,7 +184,7 @@ export default {
   }
 }
 .sr-only{
-  @include cdr-display-sr-only;
+  @include tokens.cdr-display-sr-only;
 }
 .icon {
   position: absolute;

--- a/src/components/modal/styles/CdrModal.module.scss
+++ b/src/components/modal/styles/CdrModal.module.scss
@@ -3,18 +3,18 @@
 $modal-animation-duration: 150ms;
 
 .cdr-modal {
-  @supports (-webkit-touch-callout: none) {
-    & * {
-      will-change: transform;
-    }
-  }
-
   inset: 0;
   height: 100%;
   overflow-y: scroll;
   position: fixed;
   visibility: visible;
   z-index: 9999;
+
+  @supports (-webkit-touch-callout: none) {
+    & * {
+      will-change: transform;
+    }
+  }
 
   &__overlay {
     //ITEM_DOC: Background color of the modal overlay

--- a/src/components/objectOverlay/examples/ObjectOverlay.vue
+++ b/src/components/objectOverlay/examples/ObjectOverlay.vue
@@ -177,7 +177,7 @@ defineOptions({ name: 'ObjectOverlay' });
 </template>
 
 <style lang="scss" scoped>
-@import '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens.scss';
+@use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 
 .overlay-content {
   color: white;
@@ -194,7 +194,7 @@ defineOptions({ name: 'ObjectOverlay' });
 
 .example {
   &__hr {
-    margin: $cdr-space-two-x 0;
+    margin: tokens.$cdr-space-two-x 0;
   }
 
   &__container {
@@ -203,7 +203,7 @@ defineOptions({ name: 'ObjectOverlay' });
 
   &__content {
     &--color-inverse {
-      color: $cdr-color-text-inverse;
+      color: tokens.$cdr-color-text-inverse;
     }
 
     &--narrow {

--- a/src/components/objectOverlay/styles/CdrObjectOverlay.module.scss
+++ b/src/components/objectOverlay/styles/CdrObjectOverlay.module.scss
@@ -90,7 +90,7 @@ $light-gradients: (
           }
           // Set unused positions to auto
           @each $side in top, right, bottom, left {
-            @if not map-has-key($properties, $side) {
+            @if not map.has-key($properties, $side) {
               #{$side}: auto;
             }
           }

--- a/src/components/pagination/styles/CdrPagination.module.scss
+++ b/src/components/pagination/styles/CdrPagination.module.scss
@@ -1,7 +1,7 @@
 @use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 
-@import '../../icon/styles/CdrIcon.module';
-@import '../../select/styles/CdrSelect.module';
+@use '../../icon/styles/CdrIcon.module';
+@use '../../select/styles/CdrSelect.module';
 
 .cdr-pagination {
   display: flex;
@@ -117,7 +117,7 @@
   }
 
   /* Responsive */
-  @include tokens.cdr-sm-mq {
+  @include tokens.cdr-sm-mq-up {
     &__li--links {
       display: block;
     }

--- a/src/components/pagination/styles/CdrPagination.module.scss
+++ b/src/components/pagination/styles/CdrPagination.module.scss
@@ -117,7 +117,7 @@
   }
 
   /* Responsive */
-  @include tokens.cdr-sm-mq {
+  @include tokens.cdr-sm-mq-up {
     &__li--links {
       display: block;
     }

--- a/src/components/picture/styles/CdrPicture.module.scss
+++ b/src/components/picture/styles/CdrPicture.module.scss
@@ -1,4 +1,4 @@
-@import '../../image/styles/CdrImg.module';
+@use '../../image/styles/CdrImg.module';
 
 .cdr-picture {
   max-inline-size: 100%;

--- a/src/components/popover/styles/CdrPopover.module.scss
+++ b/src/components/popover/styles/CdrPopover.module.scss
@@ -1,8 +1,8 @@
 @use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 
-@import '../../popup/styles/CdrPopup.module';
-@import '../../button/styles/CdrButton.module';
-@import '../../icon/styles/CdrIcon.module';
+@use '../../popup/styles/CdrPopup.module';
+@use '../../button/styles/CdrButton.module';
+@use '../../icon/styles/CdrIcon.module';
 
 .cdr-popover{
   &--position {

--- a/src/components/quote/styles/CdrQuote.module.scss
+++ b/src/components/quote/styles/CdrQuote.module.scss
@@ -1,6 +1,6 @@
 @use './vars/CdrQuote.vars' as vars;
 
-@import '../../text/styles/CdrText.module';
+@use '../../text/styles/CdrText.module';
 
 /* ==========================================================================
   # Cdrquote

--- a/src/components/quote/styles/vars/CdrQuote.vars.scss
+++ b/src/components/quote/styles/vars/CdrQuote.vars.scss
@@ -41,13 +41,13 @@
   //ITEM_DOC: Border color of a cdr-quote pull container
   border-color: var(--cdr-quote-pull-container-border-color, var(--cdr-color-border-primary, #{tokens.$cdr-color-border-primary}));
 
-  @include tokens.cdr-xs-mq {
+  @include tokens.cdr-xs-mq-up {
     border-width: 0 0 1px;
     padding: tokens.$cdr-space-inset-one-x-stretch;
     margin: 0 0 tokens.$cdr-space-one-x;
   }
 
-  @include tokens.cdr-sm-mq {
+  @include tokens.cdr-sm-mq-up {
     border-width: 0 0 0 1px;
     padding: tokens.$cdr-space-half-x tokens.$cdr-space-one-x tokens.$cdr-space-half-x tokens.$cdr-space-two-x;
     margin: tokens.$cdr-space-one-x 0;

--- a/src/components/radio/styles/CdrRadio.module.scss
+++ b/src/components/radio/styles/CdrRadio.module.scss
@@ -1,6 +1,6 @@
 @use './vars/CdrRadio.vars' as vars;
 
-@import '../../labelWrapper/styles/CdrLabelWrapper.module';
+@use '../../labelWrapper/styles/CdrLabelWrapper.module';
 
 .cdr-radio {
   /* Figure

--- a/src/components/rating/CdrRating.vue
+++ b/src/components/rating/CdrRating.vue
@@ -156,10 +156,7 @@ const srText = computed(() => {
       <span>
         {{ formattedCount }}
       </span>
-
-      <span v-if="!compact">
-        &nbsp;Reviews
-      </span>
+      <span v-if="!compact">&nbsp;Reviews</span>
     </span>
 
     <span :class="style['cdr-rating__caption-sr']">

--- a/src/components/rating/__tests__/__snapshots__/CdrRating.spec.js.snap
+++ b/src/components/rating/__tests__/__snapshots__/CdrRating.spec.js.snap
@@ -125,7 +125,7 @@ exports[`CdrRating > with an href > renders correctly 1`] = `
       100
     </span>
     <span>
-        Reviews 
+       Reviews
     </span>
   </span>
   <span
@@ -261,7 +261,7 @@ exports[`CdrRating > with an href > with a count of 0 > renders correctly 1`] = 
       0
     </span>
     <span>
-        Reviews 
+       Reviews
     </span>
   </span>
   <span
@@ -384,7 +384,7 @@ exports[`CdrRating > with an href > with a whole number rating > renders correct
       1
     </span>
     <span>
-        Reviews 
+       Reviews
     </span>
   </span>
   <span
@@ -526,7 +526,7 @@ exports[`CdrRating > with an href > with decimal rating and count 1 > renders co
       1
     </span>
     <span>
-        Reviews 
+       Reviews
     </span>
   </span>
   <span
@@ -668,7 +668,7 @@ exports[`CdrRating > with an href > with string input > renders correctly 1`] = 
       2
     </span>
     <span>
-        Reviews 
+       Reviews
     </span>
   </span>
   <span
@@ -893,7 +893,7 @@ exports[`CdrRating > without an href > with a count of 0 > renders correctly 1`]
       0
     </span>
     <span>
-        Reviews 
+       Reviews
     </span>
   </span>
   <span
@@ -1011,7 +1011,7 @@ exports[`CdrRating > without an href > with a count of 100 > renders correctly 1
       100
     </span>
     <span>
-        Reviews 
+       Reviews
     </span>
   </span>
   <span

--- a/src/components/select/styles/CdrSelect.module.scss
+++ b/src/components/select/styles/CdrSelect.module.scss
@@ -1,9 +1,9 @@
 @use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 @use './vars/CdrSelect.vars' as vars;
 
-@import '../../icon/styles/CdrIcon.module';
-@import '../../labelStandalone/styles/CdrLabelStandalone.module';
-@import '../../formError/styles/CdrFormError.module';
+@use '../../icon/styles/CdrIcon.module';
+@use '../../labelStandalone/styles/CdrLabelStandalone.module';
+@use '../../formError/styles/CdrFormError.module';
 
 /* ==========================================================================
   # CdrSelect

--- a/src/components/surface/examples/Surface.vue
+++ b/src/components/surface/examples/Surface.vue
@@ -3,7 +3,6 @@ import CdrSurface from '../CdrSurface.vue';
 import CdrText from '../../text/CdrText.vue';
 import CdrTitle from '../../title/CdrTitle.vue';
 import CdrButton from '../../button/CdrButton.vue';
-import CdrLink from '../../link/CdrLink.vue';
 import type { surface, HtmlAttributes } from '../../../types/interfaces';
 
 defineOptions({ name: 'Surface' });

--- a/src/components/surface/examples/Surface.vue
+++ b/src/components/surface/examples/Surface.vue
@@ -99,21 +99,21 @@ const boxes: Example[] = [
 </template>
 
 <style lang="scss" scoped>
-@import '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens.scss';
+@use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 
 .example {
   &__hr {
-    margin: $cdr-space-two-x 0;
+    margin: tokens.$cdr-space-two-x 0;
   }
 
   &__card {
     display: inline-block;
-    padding: $cdr-space-two-x;
+    padding: tokens.$cdr-space-two-x;
   }
 
   &__pill {
     display: inline-block;
-    padding: $cdr-space-half-x $cdr-space-one-x;
+    padding: tokens.$cdr-space-half-x tokens.$cdr-space-one-x;
   }
 }
 </style>

--- a/src/components/surfaceNavigation/examples/SurfaceNavigation.vue
+++ b/src/components/surfaceNavigation/examples/SurfaceNavigation.vue
@@ -111,11 +111,11 @@ const boxes: Example[] = [
 </template>
 
 <style lang="scss" scoped>
-@import '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens.scss';
+@use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 
 .example {
   &__hr {
-    margin: $cdr-space-two-x 0;
+    margin: tokens.$cdr-space-two-x 0;
   }
 }
 
@@ -129,8 +129,8 @@ const boxes: Example[] = [
   }
 
   &__image-wrapper {
-    background-color: $cdr-color-background-secondary;
-    padding: $cdr-space-inset-one-x;
+    background-color: tokens.$cdr-color-background-secondary;
+    padding: tokens.$cdr-space-inset-one-x;
   }
 
   &__image {

--- a/src/components/surfaceSelection/examples/SurfaceSelection.vue
+++ b/src/components/surfaceSelection/examples/SurfaceSelection.vue
@@ -107,27 +107,27 @@ const examples = computed(
 </template>
 
 <style lang="scss" scoped>
-@import '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens.scss';
+@use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 
 .example {
   &__hr {
-    margin: $cdr-space-two-x 0;
+    margin: tokens.$cdr-space-two-x 0;
   }
 
   &__options {
-    gap: $cdr-space-one-x;
+    gap: tokens.$cdr-space-one-x;
     display: flex;
   }
 
   &__demos {
-    gap: $cdr-space-one-x;
+    gap: tokens.$cdr-space-one-x;
     display: flex;
     flex-direction: column;
     max-width: 200px;
   }
 
   &__demos2 {
-    gap: $cdr-space-one-x;
+    gap: tokens.$cdr-space-one-x;
     display: flex;
     flex-direction: column;
     align-items: flex-start;

--- a/src/components/tabs/styles/CdrTabs.module.scss
+++ b/src/components/tabs/styles/CdrTabs.module.scss
@@ -1,6 +1,6 @@
 @use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 
-@import './CdrTabPanel.module';
+@use './CdrTabPanel.module';
 
 @mixin cdr-tabs-base-header-item-label() {
   font-family: tokens.$cdr-font-family-sans;

--- a/src/components/toast/styles/CdrToast.module.scss
+++ b/src/components/toast/styles/CdrToast.module.scss
@@ -1,8 +1,8 @@
 @use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 @use './vars/CdrToast.vars.scss' as vars;
 
-@import '../../button/styles/CdrButton.module';
-@import '../../icon/styles/CdrIcon.module';
+@use '../../button/styles/CdrButton.module';
+@use '../../icon/styles/CdrIcon.module';
 
 .cdr-toast {
   @include vars.cdr-toast-base-mixin;

--- a/src/components/tooltip/styles/CdrTooltip.module.scss
+++ b/src/components/tooltip/styles/CdrTooltip.module.scss
@@ -1,6 +1,6 @@
 @use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 
-@import '../../popup/styles/CdrPopup.module';
+@use '../../popup/styles/CdrPopup.module';
 
 .cdr-tooltip--position {
   position: relative;

--- a/src/dev/DevPage.vue
+++ b/src/dev/DevPage.vue
@@ -100,20 +100,21 @@ console.log(routes)
 </template>
 
 <style lang="scss">
-@import "../styles/main.scss";
-@import "@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens.scss";
-@import "@rei/cdr-tokens/dist/rei-dot-com/css/cdr-tokens.css";
+@use "@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens" as tokens;
+
+@use "../styles/main.scss" as main;
+@use "@rei/cdr-tokens/dist/rei-dot-com/css/cdr-tokens.css";
 
 .stack {
-  margin-top: $cdr-space-one-x;
+  margin-top: tokens.$cdr-space-one-x;
 }
 
 .mega-stack {
-  margin-top: $cdr-space-four-x;
+  margin-top: tokens.$cdr-space-four-x;
 }
 
 .inset {
-  padding: $cdr-space-one-x;
+  padding: tokens.$cdr-space-one-x;
 }
 
 .center {
@@ -121,24 +122,24 @@ console.log(routes)
 }
 
 .sr-only {
-  @include cdr-display-sr-only;
+  @include tokens.cdr-display-sr-only;
 }
 
 // root page container
 .container {
-  @include cdr-container-fluid;
+  @include tokens.cdr-container-fluid;
 }
 
 // router links at top of page
 .nav {
-  padding: $cdr-space-quarter-x;
+  padding: tokens.$cdr-space-quarter-x;
   display:inline-flex;
 }
 
 // NOTE: type examples in this file are for testing and development purposes only
 .cdr-text-dev {
   &--italic {
-    @include cdr-text-italic;
+    @include tokens.cdr-text-italic;
     font-weight: inherit;
     font-size: inherit;
     line-height: inherit;
@@ -148,7 +149,7 @@ console.log(routes)
   }
 
   &--strong {
-    @include cdr-text-strong;
+    @include tokens.cdr-text-strong;
     font-size: inherit;
     line-height: inherit;
     letter-spacing: inherit;
@@ -157,286 +158,286 @@ console.log(routes)
   }
 
   &--body {
-    &-300 { @include cdr-text-body-300; }
-    &-400 { @include cdr-text-body-400; }
-    &-500 { @include cdr-text-body-500; }
+    &-300 { @include tokens.cdr-text-body-300; }
+    &-400 { @include tokens.cdr-text-body-400; }
+    &-500 { @include tokens.cdr-text-body-500; }
     &-strong {
-      &-300 { @include cdr-text-body-strong-300; }
-      &-400 { @include cdr-text-body-strong-400; }
-      &-500 { @include cdr-text-body-strong-500; }
+      &-300 { @include tokens.cdr-text-body-strong-300; }
+      &-400 { @include tokens.cdr-text-body-strong-400; }
+      &-500 { @include tokens.cdr-text-body-strong-500; }
     }
   }
   &--utility {
     &-sans {
-      &-100 { @include cdr-text-utility-sans-100; }
-      &-200 { @include cdr-text-utility-sans-200; }
-      &-300 { @include cdr-text-utility-sans-300; }
-      &-400 { @include cdr-text-utility-sans-400; }
-      &-500 { @include cdr-text-utility-sans-500; }
-      &-600 { @include cdr-text-utility-sans-600; }
-      &-700 { @include cdr-text-utility-sans-700; }
-      &-800 { @include cdr-text-utility-sans-800; }
+      &-100 { @include tokens.cdr-text-utility-sans-100; }
+      &-200 { @include tokens.cdr-text-utility-sans-200; }
+      &-300 { @include tokens.cdr-text-utility-sans-300; }
+      &-400 { @include tokens.cdr-text-utility-sans-400; }
+      &-500 { @include tokens.cdr-text-utility-sans-500; }
+      &-600 { @include tokens.cdr-text-utility-sans-600; }
+      &-700 { @include tokens.cdr-text-utility-sans-700; }
+      &-800 { @include tokens.cdr-text-utility-sans-800; }
 
       &-strong {
-        &-100 { @include cdr-text-utility-sans-strong-100; }
-        &-200 { @include cdr-text-utility-sans-strong-200; }
-        &-300 { @include cdr-text-utility-sans-strong-300; }
-        &-400 { @include cdr-text-utility-sans-strong-400; }
-        &-500 { @include cdr-text-utility-sans-strong-500; }
-        &-600 { @include cdr-text-utility-sans-strong-600; }
-        &-700 { @include cdr-text-utility-sans-strong-700; }
-        &-800 { @include cdr-text-utility-sans-strong-800; }
+        &-100 { @include tokens.cdr-text-utility-sans-strong-100; }
+        &-200 { @include tokens.cdr-text-utility-sans-strong-200; }
+        &-300 { @include tokens.cdr-text-utility-sans-strong-300; }
+        &-400 { @include tokens.cdr-text-utility-sans-strong-400; }
+        &-500 { @include tokens.cdr-text-utility-sans-strong-500; }
+        &-600 { @include tokens.cdr-text-utility-sans-strong-600; }
+        &-700 { @include tokens.cdr-text-utility-sans-strong-700; }
+        &-800 { @include tokens.cdr-text-utility-sans-strong-800; }
       }
     }
     &-serif {
-      &-200 { @include cdr-text-utility-serif-200; }
-      &-300 { @include cdr-text-utility-serif-300; }
-      &-400 { @include cdr-text-utility-serif-400; }
-      &-500 { @include cdr-text-utility-serif-500; }
-      &-600 { @include cdr-text-utility-serif-600; }
-      &-700 { @include cdr-text-utility-serif-700; }
-      &-800 { @include cdr-text-utility-serif-800; }
+      &-200 { @include tokens.cdr-text-utility-serif-200; }
+      &-300 { @include tokens.cdr-text-utility-serif-300; }
+      &-400 { @include tokens.cdr-text-utility-serif-400; }
+      &-500 { @include tokens.cdr-text-utility-serif-500; }
+      &-600 { @include tokens.cdr-text-utility-serif-600; }
+      &-700 { @include tokens.cdr-text-utility-serif-700; }
+      &-800 { @include tokens.cdr-text-utility-serif-800; }
 
       &-strong {
-        &-200 { @include cdr-text-utility-serif-strong-200; }
-        &-300 { @include cdr-text-utility-serif-strong-300; }
-        &-400 { @include cdr-text-utility-serif-strong-400; }
-        &-500 { @include cdr-text-utility-serif-strong-500; }
-        &-600 { @include cdr-text-utility-serif-strong-600; }
-        &-700 { @include cdr-text-utility-serif-strong-700; }
-        &-800 { @include cdr-text-utility-serif-strong-800; }
+        &-200 { @include tokens.cdr-text-utility-serif-strong-200; }
+        &-300 { @include tokens.cdr-text-utility-serif-strong-300; }
+        &-400 { @include tokens.cdr-text-utility-serif-strong-400; }
+        &-500 { @include tokens.cdr-text-utility-serif-strong-500; }
+        &-600 { @include tokens.cdr-text-utility-serif-strong-600; }
+        &-700 { @include tokens.cdr-text-utility-serif-strong-700; }
+        &-800 { @include tokens.cdr-text-utility-serif-strong-800; }
       }
     }
   }
 
   &--citation {
-    @include cdr-text-utility-sans-strong-100;
+    @include tokens.cdr-text-utility-sans-strong-100;
   }
 
   &--eyebrow-100 {
-    @include cdr-text-eyebrow-100;
+    @include tokens.cdr-text-eyebrow-100;
   }
 
   &--heading {
     &-display {
-      &-800 { @include cdr-text-heading-display-800; }
-      &-900 { @include cdr-text-heading-display-900; }
-      &-1000 { @include cdr-text-heading-display-1000; }
-      &-1100 { @include cdr-text-heading-display-1100; }
-      &-1200 { @include cdr-text-heading-display-1200; }
-      &-1300 { @include cdr-text-heading-display-1300; }
-      &-1400 { @include cdr-text-heading-display-1400; }
-      &-1500 { @include cdr-text-heading-display-1500; }
-      &-1600 { @include cdr-text-heading-display-1600; }
+      &-800 { @include tokens.cdr-text-heading-display-800; }
+      &-900 { @include tokens.cdr-text-heading-display-900; }
+      &-1000 { @include tokens.cdr-text-heading-display-1000; }
+      &-1100 { @include tokens.cdr-text-heading-display-1100; }
+      &-1200 { @include tokens.cdr-text-heading-display-1200; }
+      &-1300 { @include tokens.cdr-text-heading-display-1300; }
+      &-1400 { @include tokens.cdr-text-heading-display-1400; }
+      &-1500 { @include tokens.cdr-text-heading-display-1500; }
+      &-1600 { @include tokens.cdr-text-heading-display-1600; }
     }
     &-sans {
-      &-200 { @include cdr-text-heading-sans-200; }
-      &-300 { @include cdr-text-heading-sans-300; }
-      &-400 { @include cdr-text-heading-sans-400; }
-      &-500 { @include cdr-text-heading-sans-500; }
-      &-600 { @include cdr-text-heading-sans-600; }
+      &-200 { @include tokens.cdr-text-heading-sans-200; }
+      &-300 { @include tokens.cdr-text-heading-sans-300; }
+      &-400 { @include tokens.cdr-text-heading-sans-400; }
+      &-500 { @include tokens.cdr-text-heading-sans-500; }
+      &-600 { @include tokens.cdr-text-heading-sans-600; }
     }
     &-serif {
-      &-200 { @include cdr-text-heading-serif-200; }
-      &-300 { @include cdr-text-heading-serif-300; }
-      &-400 { @include cdr-text-heading-serif-400; }
-      &-500 { @include cdr-text-heading-serif-500; }
-      &-600 { @include cdr-text-heading-serif-600; }
-      &-700 { @include cdr-text-heading-serif-700; }
-      &-800 { @include cdr-text-heading-serif-800; }
-      &-900 { @include cdr-text-heading-serif-900; }
-      &-1000 { @include cdr-text-heading-serif-1000; }
-      &-1100 { @include cdr-text-heading-serif-1100; }
-      &-1200 { @include cdr-text-heading-serif-1200; }
+      &-200 { @include tokens.cdr-text-heading-serif-200; }
+      &-300 { @include tokens.cdr-text-heading-serif-300; }
+      &-400 { @include tokens.cdr-text-heading-serif-400; }
+      &-500 { @include tokens.cdr-text-heading-serif-500; }
+      &-600 { @include tokens.cdr-text-heading-serif-600; }
+      &-700 { @include tokens.cdr-text-heading-serif-700; }
+      &-800 { @include tokens.cdr-text-heading-serif-800; }
+      &-900 { @include tokens.cdr-text-heading-serif-900; }
+      &-1000 { @include tokens.cdr-text-heading-serif-1000; }
+      &-1100 { @include tokens.cdr-text-heading-serif-1100; }
+      &-1200 { @include tokens.cdr-text-heading-serif-1200; }
       &-strong {
-        &-600 { @include cdr-text-heading-serif-strong-600; }
-        &-700 { @include cdr-text-heading-serif-strong-700; }
-        &-800 { @include cdr-text-heading-serif-strong-800; }
-        &-900 { @include cdr-text-heading-serif-strong-900; }
-        &-1000 { @include cdr-text-heading-serif-strong-1000; }
-        &-1100 { @include cdr-text-heading-serif-strong-1100; }
-        &-1200 { @include cdr-text-heading-serif-strong-1200; }
+        &-600 { @include tokens.cdr-text-heading-serif-strong-600; }
+        &-700 { @include tokens.cdr-text-heading-serif-strong-700; }
+        &-800 { @include tokens.cdr-text-heading-serif-strong-800; }
+        &-900 { @include tokens.cdr-text-heading-serif-strong-900; }
+        &-1000 { @include tokens.cdr-text-heading-serif-strong-1000; }
+        &-1100 { @include tokens.cdr-text-heading-serif-strong-1100; }
+        &-1200 { @include tokens.cdr-text-heading-serif-strong-1200; }
       }
     }
   }
 
   &--subheading {
     &-sans {
-      &-300 { @include cdr-text-subheading-sans-300; }
-      &-400 { @include cdr-text-subheading-sans-400; }
-      &-500 { @include cdr-text-subheading-sans-500; }
-      &-600 { @include cdr-text-subheading-sans-600; }
+      &-300 { @include tokens.cdr-text-subheading-sans-300; }
+      &-400 { @include tokens.cdr-text-subheading-sans-400; }
+      &-500 { @include tokens.cdr-text-subheading-sans-500; }
+      &-600 { @include tokens.cdr-text-subheading-sans-600; }
     }
   }
 
-  @include cdr-xs-mq-only {
+  @include tokens.cdr-xs-mq-only {
     &--heading {
       &-sans {
-        &-200\@xs { @include cdr-text-heading-sans-200; }
-        &-300\@xs { @include cdr-text-heading-sans-300; }
-        &-400\@xs { @include cdr-text-heading-sans-400; }
-        &-500\@xs { @include cdr-text-heading-sans-500; }
-        &-600\@xs { @include cdr-text-heading-sans-600; }
+        &-200\@xs { @include tokens.cdr-text-heading-sans-200; }
+        &-300\@xs { @include tokens.cdr-text-heading-sans-300; }
+        &-400\@xs { @include tokens.cdr-text-heading-sans-400; }
+        &-500\@xs { @include tokens.cdr-text-heading-sans-500; }
+        &-600\@xs { @include tokens.cdr-text-heading-sans-600; }
       }
       &-serif {
-        &-200\@xs { @include cdr-text-heading-serif-200; }
-        &-300\@xs { @include cdr-text-heading-serif-300; }
-        &-400\@xs { @include cdr-text-heading-serif-400; }
-        &-500\@xs { @include cdr-text-heading-serif-500; }
-        &-600\@xs { @include cdr-text-heading-serif-600; }
-        &-700\@xs { @include cdr-text-heading-serif-700; }
-        &-800\@xs { @include cdr-text-heading-serif-800; }
-        &-900\@xs { @include cdr-text-heading-serif-900; }
-        &-1000\@xs { @include cdr-text-heading-serif-1000; }
-        &-1100\@xs { @include cdr-text-heading-serif-1100; }
-        &-1200\@xs { @include cdr-text-heading-serif-1200; }
+        &-200\@xs { @include tokens.cdr-text-heading-serif-200; }
+        &-300\@xs { @include tokens.cdr-text-heading-serif-300; }
+        &-400\@xs { @include tokens.cdr-text-heading-serif-400; }
+        &-500\@xs { @include tokens.cdr-text-heading-serif-500; }
+        &-600\@xs { @include tokens.cdr-text-heading-serif-600; }
+        &-700\@xs { @include tokens.cdr-text-heading-serif-700; }
+        &-800\@xs { @include tokens.cdr-text-heading-serif-800; }
+        &-900\@xs { @include tokens.cdr-text-heading-serif-900; }
+        &-1000\@xs { @include tokens.cdr-text-heading-serif-1000; }
+        &-1100\@xs { @include tokens.cdr-text-heading-serif-1100; }
+        &-1200\@xs { @include tokens.cdr-text-heading-serif-1200; }
         &-strong {
-          &-600\@xs { @include cdr-text-heading-serif-strong-600; }
-          &-700\@xs { @include cdr-text-heading-serif-strong-700; }
-          &-800\@xs { @include cdr-text-heading-serif-strong-800; }
-          &-900\@xs { @include cdr-text-heading-serif-strong-900; }
-          &-1000\@xs { @include cdr-text-heading-serif-strong-1000; }
-          &-1100\@xs { @include cdr-text-heading-serif-strong-1100; }
-          &-1200\@xs { @include cdr-text-heading-serif-strong-1200; }
+          &-600\@xs { @include tokens.cdr-text-heading-serif-strong-600; }
+          &-700\@xs { @include tokens.cdr-text-heading-serif-strong-700; }
+          &-800\@xs { @include tokens.cdr-text-heading-serif-strong-800; }
+          &-900\@xs { @include tokens.cdr-text-heading-serif-strong-900; }
+          &-1000\@xs { @include tokens.cdr-text-heading-serif-strong-1000; }
+          &-1100\@xs { @include tokens.cdr-text-heading-serif-strong-1100; }
+          &-1200\@xs { @include tokens.cdr-text-heading-serif-strong-1200; }
         }
       }
     }
 
     &--subheading {
       &-sans {
-        &-300\@xs { @include cdr-text-subheading-sans-300; }
-        &-400\@xs { @include cdr-text-subheading-sans-400; }
-        &-500\@xs { @include cdr-text-subheading-sans-500; }
-        &-600\@xs { @include cdr-text-subheading-sans-600; }
+        &-300\@xs { @include tokens.cdr-text-subheading-sans-300; }
+        &-400\@xs { @include tokens.cdr-text-subheading-sans-400; }
+        &-500\@xs { @include tokens.cdr-text-subheading-sans-500; }
+        &-600\@xs { @include tokens.cdr-text-subheading-sans-600; }
       }
     }
   }
 
-  @include cdr-sm-mq-only {
+  @include tokens.cdr-sm-mq-only {
     &--heading {
       &-sans {
-        &-200\@sm { @include cdr-text-heading-sans-200; }
-        &-300\@sm { @include cdr-text-heading-sans-300; }
-        &-400\@sm { @include cdr-text-heading-sans-400; }
-        &-500\@sm { @include cdr-text-heading-sans-500; }
-        &-600\@sm { @include cdr-text-heading-sans-600; }
+        &-200\@sm { @include tokens.cdr-text-heading-sans-200; }
+        &-300\@sm { @include tokens.cdr-text-heading-sans-300; }
+        &-400\@sm { @include tokens.cdr-text-heading-sans-400; }
+        &-500\@sm { @include tokens.cdr-text-heading-sans-500; }
+        &-600\@sm { @include tokens.cdr-text-heading-sans-600; }
       }
       &-serif {
-        &-200\@sm { @include cdr-text-heading-serif-200; }
-        &-300\@sm { @include cdr-text-heading-serif-300; }
-        &-400\@sm { @include cdr-text-heading-serif-400; }
-        &-500\@sm { @include cdr-text-heading-serif-500; }
-        &-600\@sm { @include cdr-text-heading-serif-600; }
-        &-700\@sm { @include cdr-text-heading-serif-700; }
-        &-800\@sm { @include cdr-text-heading-serif-800; }
-        &-900\@sm { @include cdr-text-heading-serif-900; }
-        &-1000\@sm { @include cdr-text-heading-serif-1000; }
-        &-1100\@sm { @include cdr-text-heading-serif-1100; }
-        &-1200\@sm { @include cdr-text-heading-serif-1200; }
+        &-200\@sm { @include tokens.cdr-text-heading-serif-200; }
+        &-300\@sm { @include tokens.cdr-text-heading-serif-300; }
+        &-400\@sm { @include tokens.cdr-text-heading-serif-400; }
+        &-500\@sm { @include tokens.cdr-text-heading-serif-500; }
+        &-600\@sm { @include tokens.cdr-text-heading-serif-600; }
+        &-700\@sm { @include tokens.cdr-text-heading-serif-700; }
+        &-800\@sm { @include tokens.cdr-text-heading-serif-800; }
+        &-900\@sm { @include tokens.cdr-text-heading-serif-900; }
+        &-1000\@sm { @include tokens.cdr-text-heading-serif-1000; }
+        &-1100\@sm { @include tokens.cdr-text-heading-serif-1100; }
+        &-1200\@sm { @include tokens.cdr-text-heading-serif-1200; }
         &-strong {
-          &-600\@sm { @include cdr-text-heading-serif-strong-600; }
-          &-700\@sm { @include cdr-text-heading-serif-strong-700; }
-          &-800\@sm { @include cdr-text-heading-serif-strong-800; }
-          &-900\@sm { @include cdr-text-heading-serif-strong-900; }
-          &-1000\@sm { @include cdr-text-heading-serif-strong-1000; }
-          &-1100\@sm { @include cdr-text-heading-serif-strong-1100; }
-          &-1200\@sm { @include cdr-text-heading-serif-strong-1200; }
+          &-600\@sm { @include tokens.cdr-text-heading-serif-strong-600; }
+          &-700\@sm { @include tokens.cdr-text-heading-serif-strong-700; }
+          &-800\@sm { @include tokens.cdr-text-heading-serif-strong-800; }
+          &-900\@sm { @include tokens.cdr-text-heading-serif-strong-900; }
+          &-1000\@sm { @include tokens.cdr-text-heading-serif-strong-1000; }
+          &-1100\@sm { @include tokens.cdr-text-heading-serif-strong-1100; }
+          &-1200\@sm { @include tokens.cdr-text-heading-serif-strong-1200; }
         }
       }
     }
 
     &--subheading {
       &-sans {
-        &-300\@sm { @include cdr-text-subheading-sans-300; }
-        &-400\@sm { @include cdr-text-subheading-sans-400; }
-        &-500\@sm { @include cdr-text-subheading-sans-500; }
-        &-600\@sm { @include cdr-text-subheading-sans-600; }
+        &-300\@sm { @include tokens.cdr-text-subheading-sans-300; }
+        &-400\@sm { @include tokens.cdr-text-subheading-sans-400; }
+        &-500\@sm { @include tokens.cdr-text-subheading-sans-500; }
+        &-600\@sm { @include tokens.cdr-text-subheading-sans-600; }
       }
     }
   }
 
-  @include cdr-md-mq-only {
+  @include tokens.cdr-md-mq-only {
     &--heading {
       &-sans {
-        &-200\@md { @include cdr-text-heading-sans-200; }
-        &-300\@md { @include cdr-text-heading-sans-300; }
-        &-400\@md { @include cdr-text-heading-sans-400; }
-        &-500\@md { @include cdr-text-heading-sans-500; }
-        &-600\@md { @include cdr-text-heading-sans-600; }
+        &-200\@md { @include tokens.cdr-text-heading-sans-200; }
+        &-300\@md { @include tokens.cdr-text-heading-sans-300; }
+        &-400\@md { @include tokens.cdr-text-heading-sans-400; }
+        &-500\@md { @include tokens.cdr-text-heading-sans-500; }
+        &-600\@md { @include tokens.cdr-text-heading-sans-600; }
       }
       &-serif {
-        &-200\@md { @include cdr-text-heading-serif-200; }
-        &-300\@md { @include cdr-text-heading-serif-300; }
-        &-400\@md { @include cdr-text-heading-serif-400; }
-        &-500\@md { @include cdr-text-heading-serif-500; }
-        &-600\@md { @include cdr-text-heading-serif-600; }
-        &-700\@md { @include cdr-text-heading-serif-700; }
-        &-800\@md { @include cdr-text-heading-serif-800; }
-        &-900\@md { @include cdr-text-heading-serif-900; }
-        &-1000\@md { @include cdr-text-heading-serif-1000; }
-        &-1100\@md { @include cdr-text-heading-serif-1100; }
-        &-1200\@md { @include cdr-text-heading-serif-1200; }
+        &-200\@md { @include tokens.cdr-text-heading-serif-200; }
+        &-300\@md { @include tokens.cdr-text-heading-serif-300; }
+        &-400\@md { @include tokens.cdr-text-heading-serif-400; }
+        &-500\@md { @include tokens.cdr-text-heading-serif-500; }
+        &-600\@md { @include tokens.cdr-text-heading-serif-600; }
+        &-700\@md { @include tokens.cdr-text-heading-serif-700; }
+        &-800\@md { @include tokens.cdr-text-heading-serif-800; }
+        &-900\@md { @include tokens.cdr-text-heading-serif-900; }
+        &-1000\@md { @include tokens.cdr-text-heading-serif-1000; }
+        &-1100\@md { @include tokens.cdr-text-heading-serif-1100; }
+        &-1200\@md { @include tokens.cdr-text-heading-serif-1200; }
         &-strong {
-          &-600\@md { @include cdr-text-heading-serif-strong-600; }
-          &-700\@md { @include cdr-text-heading-serif-strong-700; }
-          &-800\@md { @include cdr-text-heading-serif-strong-800; }
-          &-900\@md { @include cdr-text-heading-serif-strong-900; }
-          &-1000\@md { @include cdr-text-heading-serif-strong-1000; }
-          &-1100\@md { @include cdr-text-heading-serif-strong-1100; }
-          &-1200\@md { @include cdr-text-heading-serif-strong-1200; }
+          &-600\@md { @include tokens.cdr-text-heading-serif-strong-600; }
+          &-700\@md { @include tokens.cdr-text-heading-serif-strong-700; }
+          &-800\@md { @include tokens.cdr-text-heading-serif-strong-800; }
+          &-900\@md { @include tokens.cdr-text-heading-serif-strong-900; }
+          &-1000\@md { @include tokens.cdr-text-heading-serif-strong-1000; }
+          &-1100\@md { @include tokens.cdr-text-heading-serif-strong-1100; }
+          &-1200\@md { @include tokens.cdr-text-heading-serif-strong-1200; }
         }
       }
     }
 
     &--subheading {
       &-sans {
-        &-300\@md { @include cdr-text-subheading-sans-300; }
-        &-400\@md { @include cdr-text-subheading-sans-400; }
-        &-500\@md { @include cdr-text-subheading-sans-500; }
-        &-600\@md { @include cdr-text-subheading-sans-600; }
+        &-300\@md { @include tokens.cdr-text-subheading-sans-300; }
+        &-400\@md { @include tokens.cdr-text-subheading-sans-400; }
+        &-500\@md { @include tokens.cdr-text-subheading-sans-500; }
+        &-600\@md { @include tokens.cdr-text-subheading-sans-600; }
       }
     }
   }
 
-  @include cdr-lg-mq-only {
+  @include tokens.cdr-lg-mq-only {
     &--heading {
       &-sans {
-        &-200\@lg { @include cdr-text-heading-sans-200; }
-        &-300\@lg { @include cdr-text-heading-sans-300; }
-        &-400\@lg { @include cdr-text-heading-sans-400; }
-        &-500\@lg { @include cdr-text-heading-sans-500; }
-        &-600\@lg { @include cdr-text-heading-sans-600; }
+        &-200\@lg { @include tokens.cdr-text-heading-sans-200; }
+        &-300\@lg { @include tokens.cdr-text-heading-sans-300; }
+        &-400\@lg { @include tokens.cdr-text-heading-sans-400; }
+        &-500\@lg { @include tokens.cdr-text-heading-sans-500; }
+        &-600\@lg { @include tokens.cdr-text-heading-sans-600; }
       }
       &-serif {
-        &-200\@lg { @include cdr-text-heading-serif-200; }
-        &-300\@lg { @include cdr-text-heading-serif-300; }
-        &-400\@lg { @include cdr-text-heading-serif-400; }
-        &-500\@lg { @include cdr-text-heading-serif-500; }
-        &-600\@lg { @include cdr-text-heading-serif-600; }
-        &-700\@lg { @include cdr-text-heading-serif-700; }
-        &-800\@lg { @include cdr-text-heading-serif-800; }
-        &-900\@lg { @include cdr-text-heading-serif-900; }
-        &-1000\@lg { @include cdr-text-heading-serif-1000; }
-        &-1100\@lg { @include cdr-text-heading-serif-1100; }
-        &-1200\@lg { @include cdr-text-heading-serif-1200; }
+        &-200\@lg { @include tokens.cdr-text-heading-serif-200; }
+        &-300\@lg { @include tokens.cdr-text-heading-serif-300; }
+        &-400\@lg { @include tokens.cdr-text-heading-serif-400; }
+        &-500\@lg { @include tokens.cdr-text-heading-serif-500; }
+        &-600\@lg { @include tokens.cdr-text-heading-serif-600; }
+        &-700\@lg { @include tokens.cdr-text-heading-serif-700; }
+        &-800\@lg { @include tokens.cdr-text-heading-serif-800; }
+        &-900\@lg { @include tokens.cdr-text-heading-serif-900; }
+        &-1000\@lg { @include tokens.cdr-text-heading-serif-1000; }
+        &-1100\@lg { @include tokens.cdr-text-heading-serif-1100; }
+        &-1200\@lg { @include tokens.cdr-text-heading-serif-1200; }
         &-strong {
-          &-600\@lg { @include cdr-text-heading-serif-strong-600; }
-          &-700\@lg { @include cdr-text-heading-serif-strong-700; }
-          &-800\@lg { @include cdr-text-heading-serif-strong-800; }
-          &-900\@lg { @include cdr-text-heading-serif-strong-900; }
-          &-1000\@lg { @include cdr-text-heading-serif-strong-1000; }
-          &-1100\@lg { @include cdr-text-heading-serif-strong-1100; }
-          &-1200\@lg { @include cdr-text-heading-serif-strong-1200; }
+          &-600\@lg { @include tokens.cdr-text-heading-serif-strong-600; }
+          &-700\@lg { @include tokens.cdr-text-heading-serif-strong-700; }
+          &-800\@lg { @include tokens.cdr-text-heading-serif-strong-800; }
+          &-900\@lg { @include tokens.cdr-text-heading-serif-strong-900; }
+          &-1000\@lg { @include tokens.cdr-text-heading-serif-strong-1000; }
+          &-1100\@lg { @include tokens.cdr-text-heading-serif-strong-1100; }
+          &-1200\@lg { @include tokens.cdr-text-heading-serif-strong-1200; }
         }
       }
     }
 
     &--subheading {
       &-sans {
-        &-300\@lg { @include cdr-text-subheading-sans-300; }
-        &-400\@lg { @include cdr-text-subheading-sans-400; }
-        &-500\@lg { @include cdr-text-subheading-sans-500; }
-        &-600\@lg { @include cdr-text-subheading-sans-600; }
+        &-300\@lg { @include tokens.cdr-text-subheading-sans-300; }
+        &-400\@lg { @include tokens.cdr-text-subheading-sans-400; }
+        &-500\@lg { @include tokens.cdr-text-subheading-sans-500; }
+        &-600\@lg { @include tokens.cdr-text-subheading-sans-600; }
       }
     }
   }

--- a/src/dev/SinkWrapper.vue
+++ b/src/dev/SinkWrapper.vue
@@ -65,7 +65,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens.scss';
+@use '@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 
 .sink-wrapper {
   &__radios {
@@ -77,7 +77,7 @@ export default {
   }
 
   &__container {
-    padding: $cdr-space-two-x;
+    padding: tokens.$cdr-space-two-x;
   }
 }
 </style>

--- a/src/styles/cdr-palette.scss
+++ b/src/styles/cdr-palette.scss
@@ -1,42 +1,42 @@
 /* Tokens */
-@import '/node_modules/@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens';
+@use '/node_modules/@rei/cdr-tokens/dist/rei-dot-com/scss/cdr-tokens' as tokens;
 
 // Sandstone palettes
 
 [data-palette='sandstone'] {
-  --cdr-color-background-primary: #{$cdr-color-background-secondary};
+  --cdr-color-background-primary: #{tokens.$cdr-color-background-secondary};
   --cdr-color-background-secondary: #dcd6cb;
-  --cdr-color-border-primary: #{$cdr-color-border-secondary};
+  --cdr-color-border-primary: #{tokens.$cdr-color-border-secondary};
   --cdr-color-border-secondary: #726d64;
 }
 
 // Membership palettes
 
 [data-palette='membership-subtle'] {
-  --cdr-color-background-primary: var(--cdr-membership-subtle-color-background-primary, #{$cdr-membership-subtle-color-background-primary});
-  --cdr-color-text-primary: var(--cdr-membership-subtle-color-text-primary, #{$cdr-membership-subtle-color-text-primary});
-  --cdr-color-border-button-primary-rest: var(--cdr-membership-subtle-color-border-button-primary-rest, #{$cdr-membership-subtle-color-border-button-primary-rest});
-  --cdr-color-border-button-primary-active: var(--cdr-membership-subtle-color-border-button-primary-active, #{$cdr-membership-subtle-color-border-button-primary-active});
-  --cdr-color-border-button-primary-hover: var(--cdr-membership-subtle-color-border-button-primary-hover, #{$cdr-membership-subtle-color-border-button-primary-hover});
-  --cdr-color-text-button-primary-hover: var(--cdr-membership-subtle-color-text-button-primary-hover, #{$cdr-membership-subtle-color-text-button-primary-hover});
-  --cdr-color-background-button-primary-rest: var(--cdr-membership-subtle-color-background-button-primary-rest, #{$cdr-membership-subtle-color-background-button-primary-rest});
-  --cdr-color-background-button-primary-active: var(--cdr-membership-subtle-color-background-button-primary-active, #{$cdr-membership-subtle-color-background-button-primary-active});
-  --cdr-color-text-link-rest: var(--cdr-membership-subtle-color-text-link-rest, #{$cdr-membership-subtle-color-text-link-rest});
-  --cdr-color-text-link-hover: var(--cdr-membership-subtle-color-text-link-hover, #{$cdr-membership-subtle-color-text-link-hover});
-  --cdr-color-text-link-visited: var(--cdr-membership-subtle-color-text-link-visited, #{$cdr-membership-subtle-color-text-link-visited});
+  --cdr-color-background-primary: var(--cdr-membership-subtle-color-background-primary, #{tokens.$cdr-membership-subtle-color-background-primary});
+  --cdr-color-text-primary: var(--cdr-membership-subtle-color-text-primary, #{tokens.$cdr-membership-subtle-color-text-primary});
+  --cdr-color-border-button-primary-rest: var(--cdr-membership-subtle-color-border-button-primary-rest, #{tokens.$cdr-membership-subtle-color-border-button-primary-rest});
+  --cdr-color-border-button-primary-active: var(--cdr-membership-subtle-color-border-button-primary-active, #{tokens.$cdr-membership-subtle-color-border-button-primary-active});
+  --cdr-color-border-button-primary-hover: var(--cdr-membership-subtle-color-border-button-primary-hover, #{tokens.$cdr-membership-subtle-color-border-button-primary-hover});
+  --cdr-color-text-button-primary-hover: var(--cdr-membership-subtle-color-text-button-primary-hover, #{tokens.$cdr-membership-subtle-color-text-button-primary-hover});
+  --cdr-color-background-button-primary-rest: var(--cdr-membership-subtle-color-background-button-primary-rest, #{tokens.$cdr-membership-subtle-color-background-button-primary-rest});
+  --cdr-color-background-button-primary-active: var(--cdr-membership-subtle-color-background-button-primary-active, #{tokens.$cdr-membership-subtle-color-background-button-primary-active});
+  --cdr-color-text-link-rest: var(--cdr-membership-subtle-color-text-link-rest, #{tokens.$cdr-membership-subtle-color-text-link-rest});
+  --cdr-color-text-link-hover: var(--cdr-membership-subtle-color-text-link-hover, #{tokens.$cdr-membership-subtle-color-text-link-hover});
+  --cdr-color-text-link-visited: var(--cdr-membership-subtle-color-text-link-visited, #{tokens.$cdr-membership-subtle-color-text-link-visited});
 }
 
 [data-palette='membership-vibrant'] {
-  --cdr-color-background-primary: var(--cdr-membership-vibrant-color-background-primary, #{$cdr-membership-vibrant-color-background-primary});
-  --cdr-color-text-primary: var(--cdr-membership-vibrant-color-text-primary, #{$cdr-membership-vibrant-color-text-primary});
-  --cdr-color-border-button-primary-rest: var(--cdr-membership-vibrant-color-border-button-primary-rest, #{$cdr-membership-vibrant-color-border-button-primary-rest});
-  --cdr-color-border-button-primary-active: var(--cdr-membership-vibrant-color-border-button-primary-active, #{$cdr-membership-vibrant-color-border-button-primary-active});
-  --cdr-color-border-button-primary-hover: var(--cdr-membership-vibrant-color-border-button-primary-hover, #{$cdr-membership-vibrant-color-border-button-primary-hover});
-  --cdr-color-text-button-primary-hover: var(--cdr-membership-vibrant-color-text-button-primary-hover, #{$cdr-membership-vibrant-color-text-button-primary-hover});
-  --cdr-color-background-button-primary-rest: var(--cdr-membership-vibrant-color-background-button-primary-rest, #{$cdr-membership-vibrant-color-background-button-primary-rest});
-  --cdr-color-background-button-primary-active: var(--cdr-membership-vibrant-color-background-button-primary-active, #{$cdr-membership-vibrant-color-background-button-primary-active});
-  --cdr-color-text-link-rest: var(--cdr-membership-subtle-color-text-link-rest, #{$cdr-membership-subtle-color-text-link-rest});
-  --cdr-color-text-link-hover: var(--cdr-membership-subtle-color-text-link-hover, #{$cdr-membership-subtle-color-text-link-hover});
-  --cdr-color-text-link-visited: var(--cdr-membership-subtle-color-text-link-visited, #{$cdr-membership-subtle-color-text-link-visited});
+  --cdr-color-background-primary: var(--cdr-membership-vibrant-color-background-primary, #{tokens.$cdr-membership-vibrant-color-background-primary});
+  --cdr-color-text-primary: var(--cdr-membership-vibrant-color-text-primary, #{tokens.$cdr-membership-vibrant-color-text-primary});
+  --cdr-color-border-button-primary-rest: var(--cdr-membership-vibrant-color-border-button-primary-rest, #{tokens.$cdr-membership-vibrant-color-border-button-primary-rest});
+  --cdr-color-border-button-primary-active: var(--cdr-membership-vibrant-color-border-button-primary-active, #{tokens.$cdr-membership-vibrant-color-border-button-primary-active});
+  --cdr-color-border-button-primary-hover: var(--cdr-membership-vibrant-color-border-button-primary-hover, #{tokens.$cdr-membership-vibrant-color-border-button-primary-hover});
+  --cdr-color-text-button-primary-hover: var(--cdr-membership-vibrant-color-text-button-primary-hover, #{tokens.$cdr-membership-vibrant-color-text-button-primary-hover});
+  --cdr-color-background-button-primary-rest: var(--cdr-membership-vibrant-color-background-button-primary-rest, #{tokens.$cdr-membership-vibrant-color-background-button-primary-rest});
+  --cdr-color-background-button-primary-active: var(--cdr-membership-vibrant-color-background-button-primary-active, #{tokens.$cdr-membership-vibrant-color-background-button-primary-active});
+  --cdr-color-text-link-rest: var(--cdr-membership-subtle-color-text-link-rest, #{tokens.$cdr-membership-subtle-color-text-link-rest});
+  --cdr-color-text-link-hover: var(--cdr-membership-subtle-color-text-link-hover, #{tokens.$cdr-membership-subtle-color-text-link-hover});
+  --cdr-color-text-link-visited: var(--cdr-membership-subtle-color-text-link-visited, #{tokens.$cdr-membership-subtle-color-text-link-visited});
 }
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -2,6 +2,6 @@
 @use './settings/index' as *;
 
 /* Utilities */
-@import './cdr-reset';
-@import './cdr-fonts';
-@import './cdr-palette';
+@use './cdr-reset';
+@use './cdr-fonts';
+@use './cdr-palette';

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -225,7 +225,7 @@ export interface Layout extends NameValuePair {
   as?: Component | string;
 }
 
-interface StateConfig<PropertyValue> {
+export interface StateConfig<PropertyValue> {
   rest: PropertyValue;
   hover?: PropertyValue;
   active?: PropertyValue;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,13 @@ export default defineConfig({
     modules: {
       generateScopedName: (name) => `${name}_${version.replace(/\./g, '-')}`,
     },
+    preprocessorOptions: {
+      scss: {
+        charset: false,
+        quietDeps: true,
+        api: 'modern'
+      }
+    }
   },
   resolve: {
     alias: {

--- a/vite.umd.config.ts
+++ b/vite.umd.config.ts
@@ -32,6 +32,13 @@ export default defineConfig({
     modules: {
       generateScopedName: (name) => `${name}_${version?.replace(/\./g, '-')}`,
     },
+    preprocessorOptions: {
+      scss: {
+        charset: false,
+        quietDeps: true,
+        api: 'modern'
+      }
+    }
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Description
Updates Cedar Tokens to v13, which removes support for deprecated tokens. This required the replacement of four media queries within Cedar as well in CdrBreadcrumb, CdrQuote, and CdrPagination.
Updates package version to v16.

## Checklist:

### Design:
- [ ] Reviewed with designer and meets expectations

### Cross-browser testing:
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] iOS
- [ ] Android

### Unit testing:
- [ ] Sufficient unit test coverage (see unit test best practices for ideas)
- [ ] Snapshot updates are explained with comment and reference the relevant source code change

### A11y:
- [ ] Meets WCAG AA standards

### Documentation:
- [ ] API docs created/updated
- [ ] Examples created/updated
