### PR TITLE
fix(styles): surface fluid CSS variables in dist (cdr-style.css and cdr-fluid-vars.css)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rei/cedar",
-  "version": "16.0.1",
+  "version": "16.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rei/cedar",
-      "version": "16.0.1",
+      "version": "16.0.2",
       "license": "MIT",
       "dependencies": {
         "@rei/cdr-tokens": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "16.0.1",
+  "version": "16.0.2",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -66,3 +66,4 @@ export * from './types/symbols';
 import './styles/cdr-reset.scss';
 import './styles/cdr-fonts.scss';
 import './styles/cdr-palette.scss';
+import './styles/cdr-fluid-vars.scss';

--- a/src/styles/cdr-fluid-vars.scss
+++ b/src/styles/cdr-fluid-vars.scss
@@ -1,0 +1,1 @@
+@use './settings/fluid.vars.scss' as *;


### PR DESCRIPTION
Fixes #223.

In Cedar 16.x, the migration from Sass `@import` → `@use` removed an implicit side-effect that previously emitted the fluid custom properties (e.g., `--cdr-type-scale-*`, `--cdr-space-scale-*`) into built CSS. As a result, no dist CSS artifact contained these variables, and components that referenced them (e.g., `cdr-heading-display.css`, `cdr-heading-serif.css`) regressed visually.

This PR explicitly surfaces the fluid variables in the build. They are now present in both the core stylesheet (`cdr-style.css`) and a new standalone distributable (`dist/style/cdr-fluid-vars.css`).

### Changes

- Added `src/styles/cdr-fluid-vars.scss` and imported it in `lib.ts`, so the variables are included in the core bundle (`dist/cdr-style.css`).
- Added a dedicated entrypoint for `dist/style/cdr-fluid-vars.css`, generated directly from `fluid.vars.scss`

### Usage

- Cherry-pickers: when importing component CSS directly, import the variables once globally:

```css
@import '@rei/cedar/dist/style/cdr-fluid-vars.css';
@import '@rei/cedar/dist/style/cdr-heading-display.css';
@import '@rei/cedar/dist/style/cdr-heading-serif.css';
```

### Migration Notes

- Consumers of `cdr-style.css`: no changes required.
- Consumers cherry-picking component CSS: must import `cdr-fluid-vars.css` once globally.