### PR TITLE
Pr/fix filmstrip scroll

### DIFF
--- a/src/components/filmstrip/CdrFilmstripEngine.vue
+++ b/src/components/filmstrip/CdrFilmstripEngine.vue
@@ -132,7 +132,7 @@ const surfaceScrollRef = ref<typeof CdrSurfaceScroll | null>(null);
 const containerRef = ref<HTMLElement | null>(null);
 
 // Scrollable viewport reference - computed to access the exposed viewportRef
-const viewportRef = computed(() => surfaceScrollRef.value?.viewportRef);
+const viewportRef = computed(() => (surfaceScrollRef.value?.viewportRef));
 
 // List of frame elements (each frame rendered as an <li>)
 const framesItemsRef = ref<Array<HTMLElement> | null>(null);
@@ -375,8 +375,8 @@ const debouncedHandleScroll = useDebounceFn((e: Event): void => {
 }, 100);
 
 onMounted(() => {
-  // Listen for scroll events on the viewport and handle them using the debounced scroll handler.
-  useEventListener(viewportRef, 'scroll', debouncedHandleScroll);
+   // Listen for scroll events on the viewport and handle them using the debounced scroll handler.
+  useEventListener(viewportRef.value?.viewportElement, 'scroll', debouncedHandleScroll);
 
   // Initialize a resize observer to update the container width dynamically.
   const { stop } = useResizeObserver(containerRef, (entries) => {

--- a/src/components/surfaceScroll/CdrSurfaceScroll.vue
+++ b/src/components/surfaceScroll/CdrSurfaceScroll.vue
@@ -26,7 +26,7 @@ defineExpose({ viewportRef });
   <ScrollAreaRoot
     v-bind="props.rootProps"
     :class="style['cdr-surface-scroll__root']"
-    type="always"
+    type="auto"
   >
     <ScrollAreaViewport
       ref="viewportRef"


### PR DESCRIPTION
## PR Description
### Summary
This PR fixes scroll event handling issues in the Filmstrip component and improves the scroll behavior of the SurfaceScroll component.

### Changes Made 

🔧 CdrFilmstripEngine.vue
- Fixed scroll event listener : Updated the event listener to properly access the viewport element through `viewportRef.value?.viewportElement` instead of directly using `viewportRef`
- Code formatting : Minor formatting adjustment to the computed `viewportRef` property 🔧 CdrSurfaceScroll.vue
- Improved scroll behavior : Changed ScrollAreaRoot type from "always" to "auto" for better UX - scrollbars will now only appear when content overflows

### Technical Details
The main issue was that the scroll event listener in the filmstrip was not properly accessing the DOM element. The fix ensures that:

1.  The viewport reference is correctly accessed through the component's exposed ref
2. The actual DOM element (`viewportElement`) is used for event binding
3. Scroll behavior is more intuitive with auto-showing scrollbars
### Testing
- ✅ Scroll events now properly trigger in filmstrip components
- ✅ Scrollbars appear/disappear appropriately based on content overflow
- ✅ No breaking changes to existing API
